### PR TITLE
升级PHP>=7.2，升级Guzzle>=7.0，链式同时支持同步及异步接口请求编程方式

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# ref: https://github.com/github/gitignore/blob/master/Composer.gitignore
+
+composer.phar
+/vendor/
+test/
+
+# Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
+# You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
+composer.lock

--- a/README.md
+++ b/README.md
@@ -27,24 +27,26 @@ APIv3已内置 `请求签名` 和 `应答验签` 两个middleware中间件，创
 
 我们开发和测试使用的环境如下：
 
-+ PHP 7.2+
-+ guzzlehttp/guzzle 7.0+
++ PHP ^7.2.5 || ^8.0
++ guzzlehttp/guzzle ^7.0
 
 
 ## 安装
 
-可以使用PHP包管理工具composer引入SDK到项目中：
+推荐使用PHP包管理工具`composer`引入SDK到项目中：
 
-#### Composer
 
-方式一：在项目目录中，通过composer命令行添加：
+### 方式一
+
+在项目目录中，通过composer命令行添加：
 
 ```shell
 composer require wechatpay/wechatpay
 ```
 
+### 方式二
 
-方式二：在项目的composer.json中加入以下配置：
+在项目的`composer.json`中加入以下配置：
 
 ```json
     "require": {
@@ -100,7 +102,7 @@ $instance = Builder::factory([
 - `merchant[cert => $path]` 为你的`商户证书`,一般是文件名为`apiclient_cert.pem`文件路径
 - `merchant[key => $path]` 为你的`商户API私钥`，一般是通过官方证书生成工具生成的文件名是`apiclient_key.pem`文件路径
 
-**注：** 1.0版本做了重构及优化， `APIv3`, `APIv2` 以及 `GuzzleHttp\Client` 的 `$config = []` 初始化参数，均融合在一个型参上。
+**注：** `APIv3`, `APIv2` 以及 `GuzzleHttp\Client` 的 `$config = []` 初始化参数，均融合在一个型参上。
 
 ## APIv3
 
@@ -169,7 +171,7 @@ $resp = $instance->v3->marketing->favor->media->imageUpload->postAsync([
 ### 敏感信息加/解密
 
 ```php
-// 参考上上述说明，引入 `Crypto\Rsa`
+// 参考上上述说明，引入 `WeChatPay\Crypto\Rsa`
 use WeChatPay\Crypto\Rsa;
 // 加载最新的平台证书
 $publicKey = PemUtil::loadCertificate('/path/to/wechatpay/cert.pem');
@@ -240,7 +242,7 @@ print_r($res);
 
 ### 如何下载平台证书？
 
-使用内置的平台下载器 `./bin/CertificateDownloader.php` ，验签逻辑与有`平台证书`请求其他接口一致，即在请求完成后，立即用获得的`平台证书`对返回的消息进行验签，下载器同时开启了 `Guzzle` 的 `debug => true` 方便查询请求/返回消息内容。
+使用内置的平台下载器 `./bin/CertificateDownloader.php` ，验签逻辑与有`平台证书`请求其他接口一致，即在请求完成后，立即用获得的`平台证书`对返回的消息进行验签，下载器同时开启了 `Guzzle` 的 `debug => true` 参数，方便查询请求/响应消息的基础调试信息。
 
 
 ### 证书和回调解密需要的AesGcm解密在哪里？

--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ composer require wechatpay/wechatpay
 composer install
 ```
 
+## 约定
+
+本类库是以 `OpenAPI` 对应的接入点 `URL.pathname` 以`/`做切分，映射成`segments`，编码书写方式有如下约定：
+
+1. 请求 `pathname` 切分后的每个`segment`，可直接以对象获取形式串接，例如 `v3/pay/transactions/native` 即串成 `v3->pay->transactions->native`;
+2. 每个 `pathname` 所支持的 `HTTP METHOD`，即作为被串接对象的末尾执行方法，例如: `v3->pay->transactions->native->post(['json' => []])`;
+3. 每个 `pathname` 所支持的 `HTTP METHOD`，同时支持`Async`语法糖，例如: `v3->pay->transactions->native->postAsycn(['json' => []])`;
+4. 每个 `segment` 有中线(dash)分隔符的，可以使用驼峰`camelCase`风格书写，例如: `merchant-service`可写成 `merchantService`，或如 `{'merchant-service'}`;
+5. 每个 `segment` 中，若有`uri_template`动态参数，例如 `business_code/{business_code}` 推荐以`business_code->{'{business_code}'}`形式书写，其格式语义与`pathname`基本一致，阅读起来比较自然;
+6. SDK内置的 `v2/` 对象，其特殊标识为`APIv2`级联对象，之后串接切分后的`segments`，如源 `pay/micropay` 翻译成 `v2->pay->micropay->post(['xml' => []])` 即以XML形式请求远端接口；
+7. 在IDE集成环境，也可以按照PHP内置的`ArrayIterator->offsetGet($key)`接口规范，可获取到`OpenAPI`接入点的`endpoints`，然后即可调用支持的请求方法链，例如 `offsetGet('v3/pay/transactions/jsapi')->post(['json' => []])`；
+
+以下示例用法，以`异步(Async/PromiseA+)`或`同步(Sync)`结合此种编码模式展开。
+
+> Notes: [RFC3986 #section-3.3](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.3) A path consists of a sequence of path segments separated by a slash ("/") character.
 
 ## 开始
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ use WeChatPay\Builder;
 use WeChatPay\Util\PemUtil;
 
 // 工厂方法构造一个实例
-$wxpay = Builder::factory([
+$instance = Builder::factory([
     // 商户号
     'mchid' => '1000100',
     // 商户证书序列号
@@ -108,7 +108,7 @@ $wxpay = Builder::factory([
 
 ```php
 try {
-    $resp = $wxpay->v3->pay->transactions->native->post(['json' => [/*文档参数放这里就好*/]]);
+    $resp = $instance->v3->pay->transactions->native->post(['json' => [/*文档参数放这里就好*/]]);
 
     echo $resp->getStatusCode() .' ' . $resp->getReasonPhrase()."\n";
     echo $resp->getBody() . "\n";
@@ -131,7 +131,7 @@ use WeChatPay\Util\MediaUtil;
 $media = new MediaUtil('/your/file/path/with.extension');
 
 try {
-    $resp = $wxpay['v3/merchant/media/video_upload']->post([
+    $resp = $instance['v3/merchant/media/video_upload']->post([
         'body'    => $media->getStream(),
         'headers' => [
             'content-type' => $media->getContentType(),
@@ -151,7 +151,7 @@ try {
 ### 图片上传
 
 ```php
-$resp = $wxpay->v3->marketing->favor->media->imageUpload->postAsync([
+$resp = $instance->v3->marketing->favor->media->imageUpload->postAsync([
     'body'    => $media->getStream(),
     'headers' => [
         'content-type' => $media->getContentType(),
@@ -179,7 +179,7 @@ $encryptor = function($msg) use ($publicKey) { return Rsa::encrypt($msg, $public
 // 正常使用Guzzle发起API请求
 try {
     // POST 语法糖
-    $resp = $wxpay['v3/applyment4sub/applyment/']->post([
+    $resp = $instance['v3/applyment4sub/applyment/']->post([
         'json' => [
             'business_code' => 'APL_98761234',
             'contact_info'  => [
@@ -215,7 +215,7 @@ try {
 
 ```php
 use WeChatPay\Transformer;
-$res = $wxpay->v2->mmpaymkttransfers->promotion->transfers->postAsync([
+$res = $instance->v2->mmpaymkttransfers->promotion->transfers->postAsync([
     'xml' => [
       'appid' => 'wx8888888888888888',
       'mch_id' => '1900000109',

--- a/README.md
+++ b/README.md
@@ -139,6 +139,80 @@ try {
 }
 ```
 
+### 查单
+
+```php
+$res = $instance->v3->pay->transactions->id->{'{transaction_id}'}->getAsync([
+    // 查询参数结构
+    'query' => ['mchid' => '1230000109'],
+    // uri_template 字面量参数
+    'transaction_id' => '1217752501201407033233368018',
+])
+->then(function($response) {
+    // 正常逻辑回调处理
+    echo $response->getBody()->getContents(), PHP_EOL;
+    return $response;
+})
+->otherwise(function($exception) {
+    // 异常错误处理
+    $body = $exception->getResponse()->getBody();
+    echo $body->getContents(), PHP_EOL, PHP_EOL, PHP_EOL;
+    echo $exception->getTraceAsString(), PHP_EOL;
+})
+->wait();
+```
+
+### 关单
+
+```php
+$res = $instance->v3->pay->transactions->outTradeNo->{'{out_trade_no}'}->close->postAsync([
+    // 请求参数结构
+    'json' => ['mchid' => '1230000109'],
+    // uri_template 字面量参数
+    'out_trade_no' => '1217752501201407033233368018',
+])
+->then(function($response) {
+    // 正常逻辑回调处理
+    echo $response->getBody()->getContents(), PHP_EOL;
+    return $response;
+})
+->otherwise(function($exception) {
+    // 异常错误处理
+    $body = $exception->getResponse()->getBody();
+    echo $body->getContents(), PHP_EOL, PHP_EOL, PHP_EOL;
+    echo $exception->getTraceAsString(), PHP_EOL;
+})
+->wait();
+```
+
+### 退款
+
+```php
+$res = $instance->chain('v3/refund/domestic/refunds')->postAsync([
+    'json' => [
+        'transaction_id' => '1217752501201407033233368018',
+        'out_refund_no' => '1217752501201407033233368018',
+        'amount' => [
+            'refund' => 888,
+            'total' => 888,
+            'currency' => 'CNY',
+        ],
+    ],
+])
+->then(function($response) {
+    // 正常逻辑回调处理
+    echo $response->getBody()->getContents(), PHP_EOL;
+    return $response;
+})
+->otherwise(function($exception) {
+    // 异常错误处理
+    $body = $exception->getResponse()->getBody();
+    echo $body->getContents(), PHP_EOL, PHP_EOL, PHP_EOL;
+    echo $exception->getTraceAsString(), PHP_EOL;
+})
+->wait();
+```
+
 ### 视频文件上传
 
 ```php

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ composer install
 
 ## 开始
 
-首先，通过 `WeChatPay\Builder` 工厂方法构建一个实例，然后就可以按照 [#51 链式同步或异步请求远端接口](https://github.com/wechatpay-apiv3/wechatpay-guzzle-middleware/issues/51)。
+首先，通过 `WeChatPay\Builder` 工厂方法构建一个实例，然后如上述`约定`，链式`同步`或`异步`请求远端`OpenAPI`接口。
 
 ```php
 use WeChatPay\Builder;

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ composer install
 3. 每个 `pathname` 所支持的 `HTTP METHOD`，同时支持`Async`语法糖，例如: `v3->pay->transactions->native->postAsycn(['json' => []])`;
 4. 每个 `segment` 有中线(dash)分隔符的，可以使用驼峰`camelCase`风格书写，例如: `merchant-service`可写成 `merchantService`，或如 `{'merchant-service'}`;
 5. 每个 `segment` 中，若有`uri_template`动态参数，例如 `business_code/{business_code}` 推荐以`business_code->{'{business_code}'}`形式书写，其格式语义与`pathname`基本一致，阅读起来比较自然;
-6. SDK内置的 `v2/` 对象，其特殊标识为`APIv2`级联对象，之后串接切分后的`segments`，如源 `pay/micropay` 翻译成 `v2->pay->micropay->post(['xml' => []])` 即以XML形式请求远端接口；
-7. 在IDE集成环境，也可以按照PHP内置的`ArrayIterator->offsetGet($key)`接口规范，可获取到`OpenAPI`接入点的`endpoints`，然后即可调用支持的请求方法链，例如 `offsetGet('v3/pay/transactions/jsapi')->post(['json' => []])`；
+6. SDK内置以 `v2` 特殊标识为 `APIv2` 的起始 `segmemt`，之后串接切分后的 `segments`，如源 `pay/micropay` 即串成 `v2->pay->micropay->post(['xml' => []])` 即以XML形式请求远端接口；
+7. 在IDE集成环境，也可以按照PHP内置的`ArrayIterator->offsetGet($key)`接口规范，直接以`pathname`作为变量`$key`，可获取到`OpenAPI`接入点的`endpoints`操作对象，然后即可调用支持的请求方法链，例如 `offsetGet('v3/pay/transactions/jsapi')->post(['json' => []])`；
 
 以下示例用法，以`异步(Async/PromiseA+)`或`同步(Sync)`结合此种编码模式展开。
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,259 @@
-# wechatpay-php
+# 微信支付 WeChatPay OpenAPI SDK
+
+[A]Sync Chainable WeChatPay v2&v3's OpenAPI SDK for PHP
+
+[![Packagist Stars](https://img.shields.io/packagist/stars/wechatpay/wechatpay)](https://packagist.org/packages/wechatpay/wechatpay)
+[![Packagist Downloads](https://img.shields.io/packagist/dm/wechatpay/wechatpay)](https://packagist.org/packages/wechatpay/wechatpay)
+[![Packagist Version](https://img.shields.io/packagist/v/wechatpay/wechatpay)](https://packagist.org/packages/wechatpay/wechatpay)
+[![Packagist PHP Version Support](https://img.shields.io/packagist/php-v/wechatpay/wechatpay)](https://packagist.org/packages/wechatpay/wechatpay)
+[![Packagist License](https://img.shields.io/packagist/l/wechatpay/wechatpay)](https://packagist.org/packages/wechatpay/wechatpay)
+
+## 概览
+
+微信支付 APIv2&APIv3 的[Guzzle HttpClient](http://docs.guzzlephp.org/)封装组合，
+APIv2已内置请求数据签名及`XML`转换器，应答做了数据`签名验签`，转换提供有`WeChatPay\Transformer::toArray`静态方法，按需转换；
+APIv3已内置 `请求签名` 和 `应答验签` 两个middleware中间件，创新性地实现了链式面向对象同步/异步调用远程接口。
+
+如果你是使用 `Guzzle` 的商户开发者，可以使用 `WeChatPay\Builder` 工厂方法直接创建一个 `GuzzleHttp\Client` 的链式调用封装器，
+实例在执行请求时将自动携带身份认证信息，并检查应答的微信支付签名。
+
+
+## 项目状态
+
+当前版本为`1.0.0`测试版本。请商户的专业技术人员在使用时注意系统和软件的正确性和兼容性，以及带来的风险。
+
+
+## 环境要求
+
+我们开发和测试使用的环境如下：
+
++ PHP 7.2+
++ guzzlehttp/guzzle 7.0+
+
+
+## 安装
+
+可以使用PHP包管理工具composer引入SDK到项目中：
+
+#### Composer
+
+方式一：在项目目录中，通过composer命令行添加：
+
+```shell
+composer require wechatpay/wechatpay
+```
+
+
+方式二：在项目的composer.json中加入以下配置：
+
+```json
+    "require": {
+        "wechatpay/wechatpay": "^1.0.0"
+    }
+```
+
+添加配置后，执行安装
+
+```shell
+composer install
+```
+
+
+## 开始
+
+首先，通过 `WCchatPay\Builder` 工厂方法构建一个实例，然后就可以按照 [#51 链式同步或异步请求远端接口](https://github.com/wechatpay-apiv3/wechatpay-guzzle-middleware/issues/51)。
+
+```php
+use WeChatPay\Builder;
+use WeChatPay\Util\PemUtil;
+
+// 工厂方法构造一个实例
+$wxpay = Builder::factory([
+    // 商户号
+    'mchid' => '1000100',
+    // 商户证书序列号
+    'serial' => 'XXXXXXXXXX',
+    // 商户API私钥 PEM格式的文本字符串或者文件resource
+    'privateKey' => PemUtil::loadPrivateKey('/path/to/mch/apiclient_key.pem'),
+    'certs' => [
+        // CLI `./bin/CertificateDownloader.php -m {商户号} -s {商户证书序列号} -f {商户API私钥文件路径} -k {APIv3密钥(32字节)} -o {保存地址}` 生成
+        'YYYYYYYYYY' => PemUtil::loadCertificate('/path/to/wechatpay/cert.pem')
+    ],
+    // APIv2密钥(32字节)--不使用APIv2可选
+    'secret' => 'ZZZZZZZZZZ',
+    'merchant' => [// --不使用APIv2可选
+        // 商户证书 文件路径 --不使用APIv2可选
+        'cert' => '/path/to/mch/apiclient_cert.pem',
+        // 商户API私钥 文件路径 --不使用APIv2可选
+        'key' => '/path/to/mch/apiclient_key.pem',
+    ],
+]);
+```
+
+初始化字典说明如下：
+
+- `mchid` 为你的`商户号`，一般是10字节纯数字
+- `serial` 为你的`商户证书序列号`，一般是40字节字符串
+- `privateKey` 为你的`商户API私钥`，一般是通过官方证书生成工具生成的文件名是`apiclient_key.pem`文件，支持纯字符串或者文件`resource`格式
+- `certs[$serial_number => #resource]` 为通过下载工具下载的平台证书`key/value`键值对，键为`平台证书序列号`，值为`平台证书`pem格式的纯字符串或者文件`resource`格式
+- `secret` 为APIv2版的`密钥`，商户平台上设置的32字节字符串
+- `merchant[cert => $path]` 为你的`商户证书`,一般是文件名为`apiclient_cert.pem`文件路径
+- `merchant[key => $path]` 为你的`商户API私钥`，一般是通过官方证书生成工具生成的文件名是`apiclient_key.pem`文件路径
+
+**注：** 1.0版本做了重构及优化， `APIv3`, `APIv2` 以及 `GuzzleHttp\Client` 的 `$config = []` 初始化参数，均融合在一个型参上。
+
+## APIv3
+
+### Native下单
+
+```php
+try {
+    $resp = $wxpay->v3->pay->transactions->native->post(['json' => [/*文档参数放这里就好*/]]);
+
+    echo $resp->getStatusCode() .' ' . $resp->getReasonPhrase()."\n";
+    echo $resp->getBody() . "\n";
+} catch (RequestException $e) {
+    // 进行错误处理
+    echo $e->getMessage()."\n";
+    if ($e->hasResponse()) {
+        echo $e->getResponse()->getStatusCode().' '.$e->getResponse()->getReasonPhrase()."\n";
+        echo $e->getResponse()->getBody();
+    }
+}
+```
+
+### 视频文件上传
+
+```php
+// 参考上述指引说明，并引入 `MediaUtil` 正常初始化，无额外条件
+use WeChatPay\Util\MediaUtil;
+// 实例化一个媒体文件流，注意文件后缀名需符合接口要求
+$media = new MediaUtil('/your/file/path/with.extension');
+
+try {
+    $resp = $wxpay['v3/merchant/media/video_upload']->post([
+        'body'    => $media->getStream(),
+        'headers' => [
+            'content-type' => $media->getContentType(),
+        ]
+    ]);
+    echo $resp->getStatusCode().' '.$resp->getReasonPhrase()."\n";
+    echo $resp->getBody()."\n";
+} catch (Exception $e) {
+    echo $e->getMessage()."\n";
+    if ($e->hasResponse()) {
+        echo $e->getResponse()->getStatusCode().' '.$e->getResponse()->getReasonPhrase()."\n";
+        echo $e->getResponse()->getBody();
+    }
+}
+```
+
+### 图片上传
+
+```php
+$resp = $wxpay->v3->marketing->favor->media->imageUpload->postAsync([
+    'body'    => $media->getStream(),
+    'headers' => [
+        'content-type' => $media->getContentType(),
+    ]
+])->then(function($response) {
+    echo $response->getBody()->getContents(), PHP_EOL;
+    return $response;
+})->otherwise(function($exception) {
+    $body = $exception->getResponse()->getBody();
+    echo $body->getContents(), PHP_EOL, PHP_EOL, PHP_EOL;
+    echo $exception->getTraceAsString(), PHP_EOL;
+})->wait();
+```
+
+### 敏感信息加/解密
+
+```php
+// 参考上上述说明，引入 `Crypto\Rsa`
+use WeChatPay\Crypto\Rsa;
+// 加载最新的平台证书
+$publicKey = PemUtil::loadCertificate('/path/to/wechatpay/cert.pem');
+// 做一个匿名方法，供后续方便使用
+$encryptor = function($msg) use ($publicKey) { return Rsa::encrypt($msg, $publicKey); };
+
+// 正常使用Guzzle发起API请求
+try {
+    // POST 语法糖
+    $resp = $wxpay['v3/applyment4sub/applyment/']->post([
+        'json' => [
+            'business_code' => 'APL_98761234',
+            'contact_info'  => [
+                'contact_name'      => $encryptor('value of `contact_name`'),
+                'contact_id_number' => $encryptor('value of `contact_id_number'),
+                'mobile_phone'      => $encryptor('value of `mobile_phone`'),
+                'contact_email'     => $encryptor('value of `contact_email`'),
+            ],
+            //...
+        ],
+        'headers' => [
+            // 命令行获取证书序列号
+            // openssl x509 -in /path/to/wechatpay/cert.pem -noout -serial | awk -F= '{print $2}'
+            // 或者使用工具类获取证书序列号 `PemUtil::parseCertificateSerialNo($certificate)`
+            'Wechatpay-Serial' => 'must be the serial number via the downloaded pem file of `/v3/certificates`',
+        ],
+    ]);
+    echo $resp->getStatusCode().' '.$resp->getReasonPhrase()."\n";
+    echo $resp->getBody()."\n";
+} catch (Exception $e) {
+    echo $e->getMessage()."\n";
+    if ($e->hasResponse()) {
+        echo $e->getResponse()->getStatusCode().' '.$e->getResponse()->getReasonPhrase()."\n";
+        echo $e->getResponse()->getBody();
+    }
+    return;
+}
+```
+
+## APIv2
+
+### 企业付款到零钱
+
+```php
+use WeChatPay\Transformer;
+$res = $wxpay->v2->mmpaymkttransfers->promotion->transfers->postAsync([
+    'xml' => [
+      'appid' => 'wx8888888888888888',
+      'mch_id' => '1900000109',
+      'partner_trade_no' => '10000098201411111234567890',
+      'openid' => 'oxTWIuGaIt6gTKsQRLau2M0yL16E',
+      'check_name' => 'FORCE_CHECK',
+      're_user_name' => '王小王',
+      'amount' => 10099,
+      'desc' => '理赔',
+      'spbill_create_ip' => '192.168.0.1',
+    ],
+    'security' => true,
+    'debug' => true //开启调试模式
+])
+->then(static function($response) { return Transformer::toArray($response->getBody()->getContents()); })
+->otherwise(static function($exception) { return Transformer::toArray($exception->getResponse()->getBody()->getContents()); })
+->wait();
+print_r($res);
+```
+
+## 常见问题
+
+### 如何下载平台证书？
+
+使用内置的平台下载器 `./bin/CertificateDownloader.php` ，验签逻辑与有`平台证书`请求其他接口一致，即在请求完成后，立即用获得的`平台证书`对返回的消息进行验签，下载器同时开启了 `Guzzle` 的 `debug => true` 方便查询请求/返回消息内容。
+
+
+### 证书和回调解密需要的AesGcm解密在哪里？
+
+请参考[AesGcm.php](src/Crypto/AesGcm.php)。
+
+### 配合swoole使用时，上传文件接口报错
+
+建议升级至swoole 4.6+，swoole在 4.6.0 中增加了native-curl([swoole/swoole-src#3863](https://github.com/swoole/swoole-src/pull/3863))支持，我们测试能正常使用了。
+更详细的信息，请参考[#36](https://github.com/wechatpay-apiv3/wechatpay-guzzle-middleware/issues/36)。
+
+## 联系我们
+
+如果你发现了**BUG**或者有任何疑问、建议，请通过issue进行反馈。
+
+也欢迎访问我们的[开发者社区](https://developers.weixin.qq.com/community/pay)。

--- a/README.md
+++ b/README.md
@@ -125,7 +125,17 @@ $instance = Builder::factory([
 
 ```php
 try {
-    $resp = $instance->v3->pay->transactions->native->post(['json' => [/*文档参数放这里就好*/]]);
+    $resp = $instance->v3->pay->transactions->native->post(['json' => [
+        'mchid' => '1900006XXX',
+        'out_trade_no' => 'native12177525012014070332333',
+        'appid' => 'wxdace645e0bc2cXXX',
+        'description' => 'Image形象店-深圳腾大-QQ公仔',
+        'notify_url' => 'https =>//weixin.qq.com/',
+        'amount' => [
+            'total' => 1,
+            'currency': 'CNY'
+        ],
+    ]]);
 
     echo $resp->getStatusCode() .' ' . $resp->getReasonPhrase()."\n";
     echo $resp->getBody() . "\n";
@@ -142,7 +152,8 @@ try {
 ### 查单
 
 ```php
-$res = $instance->v3->pay->transactions->id->{'{transaction_id}'}->getAsync([
+$res = $instance->v3->pay->transactions->id->{'{transaction_id}'}
+->getAsync([
     // 查询参数结构
     'query' => ['mchid' => '1230000109'],
     // uri_template 字面量参数
@@ -165,7 +176,8 @@ $res = $instance->v3->pay->transactions->id->{'{transaction_id}'}->getAsync([
 ### 关单
 
 ```php
-$res = $instance->v3->pay->transactions->outTradeNo->{'{out_trade_no}'}->close->postAsync([
+$res = $instance->v3->pay->transactions->outTradeNo->{'{out_trade_no}'}->close
+->postAsync([
     // 请求参数结构
     'json' => ['mchid' => '1230000109'],
     // uri_template 字面量参数
@@ -188,7 +200,8 @@ $res = $instance->v3->pay->transactions->outTradeNo->{'{out_trade_no}'}->close->
 ### 退款
 
 ```php
-$res = $instance->chain('v3/refund/domestic/refunds')->postAsync([
+$res = $instance->chain('v3/refund/domestic/refunds')
+->postAsync([
     'json' => [
         'transaction_id' => '1217752501201407033233368018',
         'out_refund_no' => '1217752501201407033233368018',
@@ -242,19 +255,23 @@ try {
 ### 图片上传
 
 ```php
-$resp = $instance->v3->marketing->favor->media->imageUpload->postAsync([
+$resp = $instance->v3->marketing->favor->media->imageUpload
+->postAsync([
     'body'    => $media->getStream(),
     'headers' => [
         'content-type' => $media->getContentType(),
     ]
-])->then(function($response) {
+])
+->then(function($response) {
     echo $response->getBody()->getContents(), PHP_EOL;
     return $response;
-})->otherwise(function($exception) {
+})
+->otherwise(function($exception) {
     $body = $exception->getResponse()->getBody();
     echo $body->getContents(), PHP_EOL, PHP_EOL, PHP_EOL;
     echo $exception->getTraceAsString(), PHP_EOL;
-})->wait();
+})
+->wait();
 ```
 
 ### 敏感信息加/解密
@@ -306,7 +323,8 @@ try {
 
 ```php
 use WeChatPay\Transformer;
-$res = $instance->v2->mmpaymkttransfers->promotion->transfers->postAsync([
+$res = $instance->v2->mmpaymkttransfers->promotion->transfers
+->postAsync([
     'xml' => [
       'appid' => 'wx8888888888888888',
       'mch_id' => '1900000109',

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ composer install
 4. 每个 `segment` 有中线(dash)分隔符的，可以使用驼峰`camelCase`风格书写，例如: `merchant-service`可写成 `merchantService`，或如 `{'merchant-service'}`;
 5. 每个 `segment` 中，若有`uri_template`动态参数，例如 `business_code/{business_code}` 推荐以`business_code->{'{business_code}'}`形式书写，其格式语义与`pathname`基本一致，阅读起来比较自然;
 6. SDK内置以 `v2` 特殊标识为 `APIv2` 的起始 `segmemt`，之后串接切分后的 `segments`，如源 `pay/micropay` 即串成 `v2->pay->micropay->post(['xml' => []])` 即以XML形式请求远端接口；
-7. 在IDE集成环境，也可以按照PHP内置的`ArrayIterator->offsetGet($key)`接口规范，直接以`pathname`作为变量`$key`，可获取到`OpenAPI`接入点的`endpoints`操作对象，然后即可调用支持的请求方法链，例如 `offsetGet('v3/pay/transactions/jsapi')->post(['json' => []])`；
+7. 在IDE集成环境下，也可以按照内置的`chain($segment)`接口规范，直接以`pathname`作为变量`$segment`，来获取`OpenAPI`接入点的`endpoints`串接对象，驱动末尾执行方法(填入对应参数)，发起请求，例如 `chain('v3/pay/transactions/jsapi')->post(['json' => []])`；
 
 以下示例用法，以`异步(Async/PromiseA+)`或`同步(Sync)`结合此种编码模式展开。
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ $encryptor = function($msg) use ($publicKey) { return Rsa::encrypt($msg, $public
 // 正常使用Guzzle发起API请求
 try {
     // POST 语法糖
-    $resp = $instance['v3/applyment4sub/applyment/']->post([
+    $resp = $instance->chain('v3/applyment4sub/applyment/')->post([
         'json' => [
             'business_code' => 'APL_98761234',
             'contact_info'  => [

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ composer install
 
 ## 开始
 
-首先，通过 `WCchatPay\Builder` 工厂方法构建一个实例，然后就可以按照 [#51 链式同步或异步请求远端接口](https://github.com/wechatpay-apiv3/wechatpay-guzzle-middleware/issues/51)。
+首先，通过 `WeChatPay\Builder` 工厂方法构建一个实例，然后就可以按照 [#51 链式同步或异步请求远端接口](https://github.com/wechatpay-apiv3/wechatpay-guzzle-middleware/issues/51)。
 
 ```php
 use WeChatPay\Builder;

--- a/bin/CertificateDownloader.php
+++ b/bin/CertificateDownloader.php
@@ -72,7 +72,7 @@ class CertificateDownloader
             return $response;
         }), 'injector');
 
-        $instance->offsetGet('v3/certificates')->getAsync(['debug' => true])->then(static function($response) use ($outputDir, &$certs) {
+        $instance->chain('v3/certificates')->getAsync(['debug' => true])->then(static function($response) use ($outputDir, &$certs) {
             $body = $response->getBody()->getContents();
             $body = Utils::jsonDecode($body);
             $timeZone = new \DateTimeZone('Asia/Shanghai');

--- a/bin/CertificateDownloader.php
+++ b/bin/CertificateDownloader.php
@@ -72,7 +72,7 @@ class CertificateDownloader
             return $response;
         }), 'injector');
 
-        $instance->v3->certificates->getAsync(['debug' => true])->then(static function($response) use ($outputDir, &$certs) {
+        $instance->offsetGet('v3/certificates')->getAsync(['debug' => true])->then(static function($response) use ($outputDir, &$certs) {
             $body = $response->getBody()->getContents();
             $body = Utils::jsonDecode($body);
             $timeZone = new \DateTimeZone('Asia/Shanghai');

--- a/bin/CertificateDownloader.php
+++ b/bin/CertificateDownloader.php
@@ -1,0 +1,168 @@
+#!/usr/bin/env php
+<?php
+
+// load autoload.php
+$possibleFiles = [__DIR__.'/../vendor/autoload.php', __DIR__.'/../../../autoload.php', __DIR__.'/../../autoload.php'];
+$file = null;
+foreach ($possibleFiles as $possibleFile) {
+    if (file_exists($possibleFile)) {
+        $file = $possibleFile;
+        break;
+    }
+}
+if (null === $file) {
+    throw new RuntimeException('Unable to locate autoload.php file.');
+}
+
+require_once $file;
+unset($possibleFiles, $possibleFile, $file);
+
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Utils;
+use WeChatPay\Builder;
+use WeChatPay\ClientDecoratorInterface;
+use WeChatPay\Crypto\AesGcm;
+
+class CertificateDownloader
+{
+    public function run(): void
+    {
+        $opts = $this->parseOpts();
+
+        if (!$opts) {
+            $this->printHelp();
+            exit(1);
+        }
+
+        if (isset($opts['help'])) {
+            $this->printHelp();
+            exit(0);
+        }
+        if (isset($opts['version'])) {
+            echo ClientDecoratorInterface::VERSION, PHP_EOL;
+            exit(0);
+        }
+
+        $this->downloadCert($opts);
+    }
+
+    private function downloadCert($opts): void
+    {
+        static $certs = ['any' => null];
+
+        $outputDir = $opts['output'] ?? \sys_get_temp_dir();
+        $apiv3Secret = $opts['key'];
+
+        $wxpay = Builder::factory([
+            'mchid' => $opts['mchid'],
+            'serial' => $opts['serialno'],
+            'privateKey' => \file_get_contents($opts['privatekey']),
+            'certs' => &$certs,
+        ]);
+
+        $handler = $wxpay->getDriver()->select(ClientDecoratorInterface::JSON_BASED)->getConfig('handler');
+        $handler->after('verifier', Middleware::mapResponse(static function($response) use ($apiv3Secret, &$certs) {
+            $body = $response->getBody()->getContents();
+            $body = Utils::jsonDecode($body);
+            \array_map(static function($row) use ($apiv3Secret, &$certs) {
+                $cert = $row->encrypt_certificate;
+                $certs[$row->serial_no] = AesGcm::decrypt($cert->ciphertext, $apiv3Secret, $cert->nonce, $cert->associated_data);
+            }, $body->data);
+
+            return $response;
+        }), 'injector');
+
+        $wxpay->v3->certificates->getAsync(['debug' => true])->then(static function($response) use ($outputDir, &$certs) {
+            $body = $response->getBody()->getContents();
+            $body = Utils::jsonDecode($body);
+            $timeZone = new \DateTimeZone('Asia/Shanghai');
+            \array_walk($body->data, static function($row, $index, $certs) use ($outputDir, $timeZone) {
+                $serialNo = $row->serial_no;
+                $outpath = $outputDir . DIRECTORY_SEPARATOR . 'wechatpay_' . $serialNo . '.pem';
+
+                echo 'Certificate #', $index, ' {', PHP_EOL;
+                echo '    Serial Number: ', $serialNo, PHP_EOL;
+                echo '    Not Before: ', (new \DateTime($row->effective_time, $timeZone))->format('Y-m-d H:i:s'), PHP_EOL;
+                echo '    Not After: ', (new \DateTime($row->expire_time, $timeZone))->format('Y-m-d H:i:s'), PHP_EOL;
+                echo '    Saved to: ', $outpath, PHP_EOL;
+                echo '    Content: ', PHP_EOL, PHP_EOL, $certs[$serialNo], PHP_EOL, PHP_EOL;
+                echo '}', PHP_EOL;
+
+                \file_put_contents($outpath, $certs[$serialNo]);
+            }, $certs);
+
+            return $response;
+        })->otherwise(static function($exception) {
+            $body = $exception->getResponse()->getBody();
+            echo $body->getContents(), PHP_EOL, PHP_EOL, PHP_EOL;
+            echo $exception->getTraceAsString(), PHP_EOL;
+        })->wait();
+    }
+
+    private function parseOpts(): ?array
+    {
+        $opts = [
+            [ 'key', 'k', true ],
+            [ 'mchid', 'm', true ],
+            [ 'privatekey', 'f', true ],
+            [ 'serialno', 's', true ],
+            [ 'output', 'o', false ],
+        ];
+
+        $shortopts = 'hV';
+        $longopts = [ 'help', 'version' ];
+        foreach ($opts as $opt) {
+            $shortopts .= $opt[1].':';
+            $longopts[] = $opt[0].':';
+        }
+        $parsed = \getopt($shortopts, $longopts);
+
+
+        if (!$parsed) {
+            return null;
+        }
+
+        $args = [];
+        foreach ($opts as $opt) {
+            if (isset($parsed[$opt[0]])) {
+                $args[$opt[0]] = $parsed[$opt[0]];
+            }
+            else if (isset($parsed[$opt[1]])) {
+                $args[$opt[0]] = $parsed[$opt[1]];
+            }
+            else if ($opt[2]) {
+                return null;
+            }
+        }
+
+        if (isset($parsed['h']) || isset($parsed['help'])) {
+            $args['help'] = true;
+        }
+        if (isset($parsed['V']) || isset($parsed['version'])) {
+            $args['version'] = true;
+        }
+        return $args;
+    }
+
+    private function printHelp(): void
+    {
+        echo <<<EOD
+Usage: 微信支付平台证书下载工具 [-hV]
+                    -f=<privateKeyFilePath> -k=<apiV3key> -m=<merchantId>
+                    -o=[outputFilePath] -s=<serialNo>
+  -m, --mchid=<merchantId>   商户号
+  -s, --serialno=<serialNo>  商户证书的序列号
+  -f, --privatekey=<privateKeyFilePath>
+                             商户的私钥文件
+  -k, --key=<apiV3key>       ApiV3Key
+  -o, --output=[outputFilePath]
+                             下载成功后保存证书的路径，可选参数，默认为临时文件目录夹
+  -V, --version              Print version information and exit.
+  -h, --help                 Show this help message and exit.
+
+EOD;
+    }
+}
+
+// main
+(new CertificateDownloader())->run();

--- a/bin/CertificateDownloader.php
+++ b/bin/CertificateDownloader.php
@@ -53,14 +53,14 @@ class CertificateDownloader
         $outputDir = $opts['output'] ?? \sys_get_temp_dir();
         $apiv3Secret = $opts['key'];
 
-        $wxpay = Builder::factory([
+        $instance = Builder::factory([
             'mchid' => $opts['mchid'],
             'serial' => $opts['serialno'],
             'privateKey' => \file_get_contents($opts['privatekey']),
             'certs' => &$certs,
         ]);
 
-        $handler = $wxpay->getDriver()->select(ClientDecoratorInterface::JSON_BASED)->getConfig('handler');
+        $handler = $instance->getDriver()->select(ClientDecoratorInterface::JSON_BASED)->getConfig('handler');
         $handler->after('verifier', Middleware::mapResponse(static function($response) use ($apiv3Secret, &$certs) {
             $body = $response->getBody()->getContents();
             $body = Utils::jsonDecode($body);
@@ -72,7 +72,7 @@ class CertificateDownloader
             return $response;
         }), 'injector');
 
-        $wxpay->v3->certificates->getAsync(['debug' => true])->then(static function($response) use ($outputDir, &$certs) {
+        $instance->v3->certificates->getAsync(['debug' => true])->then(static function($response) use ($outputDir, &$certs) {
             $body = $response->getBody()->getContents();
             $body = Utils::jsonDecode($body);
             $timeZone = new \DateTimeZone('Asia/Shanghai');

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,44 @@
+# Certificate Downloader
+
+Certificate Downloader 是 PHP版 微信支付 APIv3 平台证书的命令行下载工具。该工具可从 `https://api.mch.weixin.qq.com/v3/certificates` 接口获取商户可用证书，并使用 [APIv3 密钥](https://wechatpay-api.gitbook.io/wechatpay-api-v3/ren-zheng/api-v3-mi-yao) 和 AES_256_GCM 算法进行解密，并把解密后证书下载到指定位置。
+
+## 使用
+使用方法与 [Java版Certificate Downloader](https://github.com/wechatpay-apiv3/CertificateDownloader) 一致，参数与常见问题请参考[其文档](https://github.com/wechatpay-apiv3/CertificateDownloader/blob/master/README.md)。
+
+```shell
+> php bin/CertificateDownloader.php
+
+Usage: 微信支付平台证书下载工具 [-hV]
+                    -f=<privateKeyFilePath> -k=<apiV3key> -m=<merchantId>
+                    -o=[outputFilePath] -s=<serialNo>
+  -m, --mchid=<merchantId>   商户号
+  -s, --serialno=<serialNo>  商户证书的序列号
+  -f, --privatekey=<privateKeyFilePath>
+                             商户的私钥文件
+  -k, --key=<apiV3key>       ApiV3Key
+  -o, --output=[outputFilePath]
+                             下载成功后保存证书的路径，可选参数，默认为临时文件目录夹
+  -V, --version              Print version information and exit.
+  -h, --help                 Show this help message and exit.
+```
+
+完整命令示例：
+
+```shell
+./bin/CertificateDownloader.php -k ${apiV3key} -m ${mchId} -f ${mchPrivateKeyFilePath} -s ${mchSerialNo} -o ${outputFilePath}
+```
+
+
+
+## 常见问题
+
+### 如何保证证书正确
+请参见CertificateDownloader文档中[关于如何保证证书正确的说明](https://github.com/wechatpay-apiv3/CertificateDownloader#%E5%A6%82%E4%BD%95%E4%BF%9D%E8%AF%81%E8%AF%81%E4%B9%A6%E6%AD%A3%E7%A1%AE)。
+
+### 如何使用信任链验证平台证书
+请参见CertificateDownloader文档中[关于如何使用信任链验证平台证书的说明](https://github.com/wechatpay-apiv3/CertificateDownloader#%E5%A6%82%E4%BD%95%E4%BD%BF%E7%94%A8%E4%BF%A1%E4%BB%BB%E9%93%BE%E9%AA%8C%E8%AF%81%E5%B9%B3%E5%8F%B0%E8%AF%81%E4%B9%A6)。
+
+### 第一次下载证书
+
+请参见CertificateDownloader文档中[相关说明](https://github.com/wechatpay-apiv3/CertificateDownloader#%E7%AC%AC%E4%B8%80%E6%AC%A1%E4%B8%8B%E8%BD%BD%E8%AF%81%E4%B9%A6)。
+

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,45 @@
+{
+    "name": "wechatpay/wechatpay",
+    "version": "1.0.0",
+    "description": "[A]Sync Chainable WeChatPay v2&v3's OpenAPI SDK for PHP",
+    "type": "library",
+    "keywords": [
+        "wechatpay",
+        "chainable HTTP requests client",
+        "xml-parser",
+        "xml-builder",
+        "aes-ecb",
+        "aes-gcm",
+        "rsa-oaep"
+    ],
+    "authors": [
+        {
+            "name": "WeChatPay Community",
+            "homepage": "https://developers.weixin.qq.com/community/pay"
+        }
+    ],
+    "homepage": "https://pay.weixin.qq.com/",
+    "license": "Apache-2.0",
+    "require": {
+        "php": ">=7.2.5",
+        "ext-curl": "*",
+        "ext-libxml": "*",
+        "ext-simplexml": "*",
+        "ext-openssl": "*",
+        "guzzlehttp/uri-template": "*",
+        "guzzlehttp/guzzle": "^7.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "*"
+    },
+    "autoload": {
+        "psr-4": { "WeChatPay\\" : "src/" }
+    },
+    "bin": [
+        "bin/CertificateDownloader.php"
+    ],
+    "suggest": {
+        "guzzlehttp/uri-template": "For using wechatpay guzzle url-template(RFC6570) feature.",
+        "guzzlehttp/guzzle": "For using wechatpay guzzle middleware."
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5.5 || ^9.3.5"
+        "phpunit/phpunit": "^8.5.5 || ^9.3.5",
+        "phpstan/phpstan": "^0.12.89"
     },
     "autoload": {
         "psr-4": { "WeChatPay\\" : "src/" }

--- a/composer.json
+++ b/composer.json
@@ -21,25 +21,21 @@
     "homepage": "https://pay.weixin.qq.com/",
     "license": "Apache-2.0",
     "require": {
-        "php": ">=7.2.5",
+        "php": "^7.2.5 || ^8.0",
         "ext-curl": "*",
         "ext-libxml": "*",
         "ext-simplexml": "*",
         "ext-openssl": "*",
-        "guzzlehttp/uri-template": "*",
+        "guzzlehttp/uri-template": "^0.2",
         "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "^8.5.5 || ^9.3.5"
     },
     "autoload": {
         "psr-4": { "WeChatPay\\" : "src/" }
     },
     "bin": [
         "bin/CertificateDownloader.php"
-    ],
-    "suggest": {
-        "guzzlehttp/uri-template": "For using wechatpay guzzle url-template(RFC6570) feature.",
-        "guzzlehttp/guzzle": "For using wechatpay guzzle middleware."
-    }
+    ]
 }

--- a/php7.phpstan.neon
+++ b/php7.phpstan.neon
@@ -1,0 +1,5 @@
+includes:
+	- phpstan.neon.dist
+parameters:
+	ignoreErrors:
+		- '#invalid(?: typehint)? type OpenSSL(?:Certificate|AsymmetricKey)#'

--- a/php7.phpstan.neon
+++ b/php7.phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-	- phpstan.neon.dist
+  - phpstan.neon.dist
 parameters:
-	ignoreErrors:
-		- '#invalid(?: typehint)? type OpenSSL(?:Certificate|AsymmetricKey)#'
+  ignoreErrors:
+    - '#invalid(?: typehint)? type OpenSSL(?:Certificate|AsymmetricKey)#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,52 +11,52 @@ parameters:
 			path: src/Builder.php
 
 		-
-			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:delete\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: "#^Method class@anonymous/src/Builder\\.php\\:47\\:\\:delete\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Builder.php
 
 		-
-			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:deleteAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: "#^Method class@anonymous/src/Builder\\.php\\:47\\:\\:deleteAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Builder.php
 
 		-
-			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:get\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: "#^Method class@anonymous/src/Builder\\.php\\:47\\:\\:get\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Builder.php
 
 		-
-			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:getAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: "#^Method class@anonymous/src/Builder\\.php\\:47\\:\\:getAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Builder.php
 
 		-
-			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:patch\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: "#^Method class@anonymous/src/Builder\\.php\\:47\\:\\:patch\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Builder.php
 
 		-
-			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:patchAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: "#^Method class@anonymous/src/Builder\\.php\\:47\\:\\:patchAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Builder.php
 
 		-
-			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:post\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: "#^Method class@anonymous/src/Builder\\.php\\:47\\:\\:post\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Builder.php
 
 		-
-			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:postAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: "#^Method class@anonymous/src/Builder\\.php\\:47\\:\\:postAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Builder.php
 
 		-
-			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:put\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: "#^Method class@anonymous/src/Builder\\.php\\:47\\:\\:put\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Builder.php
 
 		-
-			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:putAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: "#^Method class@anonymous/src/Builder\\.php\\:47\\:\\:putAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Builder.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -111,11 +111,6 @@ parameters:
 			path: src/BuilderChainable.php
 
 		-
-			message: "#^Function uri_template not found\\.$#"
-			count: 1
-			path: src/ClientDecorator.php
-
-		-
 			message: "#^Method WeChatPay\\\\ClientDecorator\\:\\:__construct\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/ClientDecorator.php
@@ -229,4 +224,3 @@ parameters:
 			message: "#^Variable \\$previous might not be defined\\.$#"
 			count: 1
 			path: src/Transformer.php
-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -141,11 +141,6 @@ parameters:
 			path: src/ClientDecorator.php
 
 		-
-			message: "#^Method WeChatPay\\\\ClientDecorator\\:\\:transformRequest\\(\\) has parameter \\$merchant with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/ClientDecorator.php
-
-		-
 			message: "#^Method WeChatPay\\\\ClientDecorator\\:\\:withDefaults\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/ClientDecorator.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,237 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Cannot access property \\$data on array\\|bool\\|float\\|int\\|object\\|string\\.$#"
+			count: 2
+			path: bin/CertificateDownloader.php
+
+		-
+			message: "#^Method WeChatPay\\\\Builder\\:\\:factory\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Builder.php
+
+		-
+			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:delete\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Builder.php
+
+		-
+			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:deleteAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Builder.php
+
+		-
+			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:get\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Builder.php
+
+		-
+			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:getAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Builder.php
+
+		-
+			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:patch\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Builder.php
+
+		-
+			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:patchAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Builder.php
+
+		-
+			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:post\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Builder.php
+
+		-
+			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:postAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Builder.php
+
+		-
+			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:put\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Builder.php
+
+		-
+			message: "#^Method class@anonymous/src/Builder\\.php\\:45\\:\\:putAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Builder.php
+
+		-
+			message: "#^Method WeChatPay\\\\BuilderChainable\\:\\:delete\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/BuilderChainable.php
+
+		-
+			message: "#^Method WeChatPay\\\\BuilderChainable\\:\\:deleteAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/BuilderChainable.php
+
+		-
+			message: "#^Method WeChatPay\\\\BuilderChainable\\:\\:get\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/BuilderChainable.php
+
+		-
+			message: "#^Method WeChatPay\\\\BuilderChainable\\:\\:getAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/BuilderChainable.php
+
+		-
+			message: "#^Method WeChatPay\\\\BuilderChainable\\:\\:patch\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/BuilderChainable.php
+
+		-
+			message: "#^Method WeChatPay\\\\BuilderChainable\\:\\:patchAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/BuilderChainable.php
+
+		-
+			message: "#^Method WeChatPay\\\\BuilderChainable\\:\\:post\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/BuilderChainable.php
+
+		-
+			message: "#^Method WeChatPay\\\\BuilderChainable\\:\\:postAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/BuilderChainable.php
+
+		-
+			message: "#^Method WeChatPay\\\\BuilderChainable\\:\\:put\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/BuilderChainable.php
+
+		-
+			message: "#^Method WeChatPay\\\\BuilderChainable\\:\\:putAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/BuilderChainable.php
+
+		-
+			message: "#^Function uri_template not found\\.$#"
+			count: 1
+			path: src/ClientDecorator.php
+
+		-
+			message: "#^Method WeChatPay\\\\ClientDecorator\\:\\:__construct\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientDecorator.php
+
+		-
+			message: "#^Method WeChatPay\\\\ClientDecorator\\:\\:jsonBased\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientDecorator.php
+
+		-
+			message: "#^Method WeChatPay\\\\ClientDecorator\\:\\:request\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientDecorator.php
+
+		-
+			message: "#^Method WeChatPay\\\\ClientDecorator\\:\\:requestAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientDecorator.php
+
+		-
+			message: "#^Method WeChatPay\\\\ClientDecorator\\:\\:signer\\(\\) has parameter \\$privateKey with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientDecorator.php
+
+		-
+			message: "#^Method WeChatPay\\\\ClientDecorator\\:\\:transformRequest\\(\\) has parameter \\$merchant with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientDecorator.php
+
+		-
+			message: "#^Method WeChatPay\\\\ClientDecorator\\:\\:withDefaults\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientDecorator.php
+
+		-
+			message: "#^Method WeChatPay\\\\ClientDecorator\\:\\:xmlBased\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientDecorator.php
+
+		-
+			message: "#^Method WeChatPay\\\\ClientDecoratorInterface\\:\\:request\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientDecoratorInterface.php
+
+		-
+			message: "#^Method WeChatPay\\\\ClientDecoratorInterface\\:\\:requestAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientDecoratorInterface.php
+
+		-
+			message: "#^Method WeChatPay\\\\Crypto\\\\Rsa\\:\\:decrypt\\(\\) has parameter \\$privateKey with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Crypto/Rsa.php
+
+		-
+			message: "#^Method WeChatPay\\\\Crypto\\\\Rsa\\:\\:encrypt\\(\\) has parameter \\$publicKey with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Crypto/Rsa.php
+
+		-
+			message: "#^Method WeChatPay\\\\Crypto\\\\Rsa\\:\\:sign\\(\\) has parameter \\$privateKey with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Crypto/Rsa.php
+
+		-
+			message: "#^Method WeChatPay\\\\Crypto\\\\Rsa\\:\\:verify\\(\\) has parameter \\$publicKey with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Crypto/Rsa.php
+
+		-
+			message: "#^Method WeChatPay\\\\Transformer\\:\\:cast\\(\\) has parameter \\$thing with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Transformer.php
+
+		-
+			message: "#^Method WeChatPay\\\\Transformer\\:\\:cast\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Transformer.php
+
+		-
+			message: "#^Method WeChatPay\\\\Transformer\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Transformer.php
+
+		-
+			message: "#^Method WeChatPay\\\\Transformer\\:\\:toXml\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Transformer.php
+
+		-
+			message: "#^Method WeChatPay\\\\Transformer\\:\\:value\\(\\) has parameter \\$thing with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Transformer.php
+
+		-
+			message: "#^Method WeChatPay\\\\Transformer\\:\\:walk\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Transformer.php
+
+		-
+			message: "#^PHPDoc tag @param for parameter \\$writer with type XMLWritter is not subtype of native type XMLWriter\\.$#"
+			count: 2
+			path: src/Transformer.php
+
+		-
+			message: "#^Parameter \\$writer of method WeChatPay\\\\Transformer\\:\\:content\\(\\) has invalid typehint type XMLWritter\\.$#"
+			count: 1
+			path: src/Transformer.php
+
+		-
+			message: "#^Parameter \\$writer of method WeChatPay\\\\Transformer\\:\\:walk\\(\\) has invalid typehint type XMLWritter\\.$#"
+			count: 1
+			path: src/Transformer.php
+
+		-
+			message: "#^Variable \\$previous might not be defined\\.$#"
+			count: 1
+			path: src/Transformer.php
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,8 @@
+parameters:
+	paths:
+		- src
+	level: 5
+	ignoreErrors:
+		- '#Function uri_template not found#'
+		- '#Variable \$previous might not be defined#'
+		- '#\$writer (.*?) type XMLWritter#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,8 +1,10 @@
 parameters:
-	paths:
-		- src
-	level: 5
-	ignoreErrors:
-		- '#Function uri_template not found#'
-		- '#Variable \$previous might not be defined#'
-		- '#\$writer (.*?) type XMLWritter#'
+  level: 5
+  paths:
+    - src
+    - bin
+  ignoreErrors:
+    - '#Function uri_template not found#'
+    - '#Variable \$previous might not be defined#'
+    - '#\$writer (.*?) type XMLWritter#'
+    - '#Cannot access property \$data on array\|bool\|float\|int\|object\|string.#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,10 +1,7 @@
+includes:
+  - phpstan-baseline.neon
 parameters:
-  level: 5
+  level: 6
   paths:
     - src
     - bin
-  ignoreErrors:
-    - '#Function uri_template not found#'
-    - '#Variable \$previous might not be defined#'
-    - '#\$writer (.*?) type XMLWritter#'
-    - '#Cannot access property \$data on array\|bool\|float\|int\|object\|string.#'

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -134,6 +134,14 @@ final class Builder
 
                 return parent::offsetGet($key);
             }
+
+            /**
+             * @inheritDoc
+             */
+            public function chain($segment): BuilderChainable
+            {
+                return $this->offsetGet($segment);
+            }
         };
     }
 

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -28,15 +28,15 @@ final class Builder
      * $instance->v3->certificates->getAsync()->then(function() {})->otherwise(function() {})->wait();
      * ```
      *
-     * @param array $config - configuration
-     * @param string|int $config[mchid] - The merchant ID
-     * @param string $config[serial] - The serial number of the merchant certificate
-     * @param OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string $config[privateKey] - The merchant private key.
-     * @param array $config[certs] - The WeChatPay platform serial and certificate(s), `[serial => certificate]` pair
-     * @param string [$config[secret] = null] - The secret key string
-     * @param array [$config[merchant] = null] - The merchant private key and certificate array
-     * @param string [$config[merchant[key]] = null] - The merchant private key(file path string).
-     * @param string [$config[merchant[cert]] = null] - The merchant certificate(file path string).
+     * Acceptable \$config parameters stucture
+     *   - mchid: string - The merchant ID
+     *   - serial: string - The serial number of the merchant certificate
+     *   - privateKey: OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string - The merchant private key.
+     *   - certs: [$key:string => $value: mixed] - The wechatpay platform serial and certificate(s)
+     *   - secret: ?string - The secret key string (optional)
+     *   - merchant: ?array - The merchant private key and certificate array (optional)
+     *   - merchant<key: ?string> - The merchant private key(file path string). (optional)
+     *   - merchant<cert: ?string> - The merchant certificate(file path string). (optional)
      *
      * @return BuilderChainable - The chainable client
      */
@@ -86,7 +86,7 @@ final class Builder
              *                                    & `camelCase` -> `camel-case`
              *                                    & `_dynamic_` -> `{dynamic}`
              *
-             * @param string thing - The string waiting for normalization
+             * @param string $thing - The string waiting for normalization
              *
              * @return string
              */
@@ -102,7 +102,7 @@ final class Builder
             /**
              * URI pathname
              *
-             * @param string [$seperator = '/'] - The URI seperator
+             * @param string $seperator- The URI seperator, default is slash(`/`) character
              *
              * @return string - The URI string
              */

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -21,11 +21,11 @@ final class Builder
      *
      * ```php
      * // samples
-     * $wxpay = Builder::factory([]);
-     * $res = $wxpay['v3/merchantService/complaintsV2']->get(['debug' => true]);
-     * $res = $wxpay['v3/merchant-service/complaint-notifications']->get(['debug' => true]);
-     * $wxpay->v3->merchantService->ComplaintNotifications->postAsync([])->wait();
-     * $wxpay->v3->certificates->getAsync()->then()->otherwise()->wait();
+     * $instance = Builder::factory([]);
+     * $res = $instance['v3/merchantService/complaintsV2']->get(['debug' => true]);
+     * $res = $instance['v3/merchant-service/complaint-notifications']->get(['debug' => true]);
+     * $instance->v3->merchantService->ComplaintNotifications->postAsync([])->wait();
+     * $instance->v3->certificates->getAsync()->then()->otherwise()->wait();
      * ```
      *
      * @param array $config - configuration

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -22,8 +22,8 @@ final class Builder
      * ```php
      * // usage samples
      * $instance = Builder::factory([]);
-     * $res = $instance['v3/merchantService/complaintsV2']->get(['debug' => true]);
-     * $res = $instance['v3/merchant-service/complaint-notifications']->get(['debug' => true]);
+     * $res = $instance->chain('v3/merchantService/complaintsV2')->get(['debug' => true]);
+     * $res = $instance->chain('v3/merchant-service/complaint-notifications')->get(['debug' => true]);
      * $instance->v3->merchantService->ComplaintNotifications->postAsync([])->wait();
      * $instance->v3->certificates->getAsync()->then(function() {})->otherwise(function() {})->wait();
      * ```
@@ -31,12 +31,12 @@ final class Builder
      * Acceptable \$config parameters stucture
      *   - mchid: string - The merchant ID
      *   - serial: string - The serial number of the merchant certificate
-     *   - privateKey: OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string - The merchant private key.
-     *   - certs: [$key:string => $value: mixed] - The wechatpay platform serial and certificate(s)
-     *   - secret: ?string - The secret key string (optional)
-     *   - merchant: ?array - The merchant private key and certificate array (optional)
-     *   - merchant<key: ?string> - The merchant private key(file path string). (optional)
-     *   - merchant<cert: ?string> - The merchant certificate(file path string). (optional)
+     *   - privateKey: \OpenSSLAsymmetricKey|\OpenSSLCertificate|resource|array|string - The merchant private key.
+     *   - certs: array<string, \OpenSSLAsymmetricKey|\OpenSSLCertificate|resource|array|string> - The wechatpay platform serial and certificate(s)
+     *   - secret?: string - The secret key string (optional)
+     *   - merchant?: array{key?: string, cert?: string} - The merchant private key and certificate array. (optional)
+     *   - merchant<?key, string> - The merchant private key(file path string). (optional)
+     *   - merchant<?cert, string> - The merchant certificate(file path string). (optional)
      *
      * @return BuilderChainable - The chainable client
      */
@@ -48,6 +48,8 @@ final class Builder
 
             /**
              * Compose the chainable `ClientDecorator` instance, most starter with the tree root point
+             * @param array<string|int> $input
+             * @param ?ClientDecoratorInterface $instance
              */
             public function __construct(array $input = [], ?ClientDecoratorInterface $instance = null) {
                 parent::__construct($input, self::STD_PROP_LIST | self::ARRAY_AS_PROPS);
@@ -102,7 +104,7 @@ final class Builder
             /**
              * URI pathname
              *
-             * @param string $seperator- The URI seperator, default is slash(`/`) character
+             * @param string $seperator - The URI seperator, default is slash(`/`) character
              *
              * @return string - The URI string
              */
@@ -112,9 +114,9 @@ final class Builder
             }
 
             /**
-             * Only retrieve a copy array of the URI entities
+             * Only retrieve a copy array of the URI segments
              *
-             * @return array - The URI entities' array
+             * @return array<string|int> - The URI segments array
              */
             protected function simplized(): array
             {

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -20,12 +20,12 @@ final class Builder
      * Building & decorate the chainable `GuzzleHttp\Client`
      *
      * ```php
-     * // samples
+     * // usage samples
      * $instance = Builder::factory([]);
      * $res = $instance['v3/merchantService/complaintsV2']->get(['debug' => true]);
      * $res = $instance['v3/merchant-service/complaint-notifications']->get(['debug' => true]);
      * $instance->v3->merchantService->ComplaintNotifications->postAsync([])->wait();
-     * $instance->v3->certificates->getAsync()->then()->otherwise()->wait();
+     * $instance->v3->certificates->getAsync()->then(function() {})->otherwise(function() {})->wait();
      * ```
      *
      * @param array $config - configuration
@@ -122,11 +122,7 @@ final class Builder
             }
 
             /**
-             * Chainable the given `$key` with the `ClientDecoratorInterface` instance
-             *
-             * @param string|int $key - The key
-             *
-             * @return BuilderChainable
+             * @inheritDoc
              */
             public function offsetGet($key): BuilderChainable
             {

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace WeChatPay;
+
+use function preg_replace;
+use function preg_replace_callback;
+use function strtolower;
+use function implode;
+use function array_filter;
+use function array_push;
+
+use ArrayIterator;
+
+/**
+ * Chainable the client for sending HTTP requests.
+ */
+final class Builder
+{
+    /**
+     * Building & decorate the chainable `GuzzleHttp\Client`
+     *
+     * ```php
+     * // samples
+     * $wxpay = Builder::factory([]);
+     * $res = $wxpay['v3/merchantService/complaintsV2']->get(['debug' => true]);
+     * $res = $wxpay['v3/merchant-service/complaint-notifications']->get(['debug' => true]);
+     * $wxpay->v3->merchantService->ComplaintNotifications->postAsync([])->wait();
+     * $wxpay->v3->certificates->getAsync()->then()->otherwise()->wait();
+     * ```
+     *
+     * @param array $config - configuration
+     * @param string|int $config[mchid] - The merchant ID
+     * @param string $config[serial] - The serial number of the merchant certificate
+     * @param OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string $config[privateKey] - The merchant private key.
+     * @param array $config[certs] - The WeChatPay platform serial and certificate(s), `[serial => certificate]` pair
+     * @param string [$config[secret] = null] - The secret key string
+     * @param array [$config[merchant] = null] - The merchant private key and certificate array
+     * @param string [$config[merchant[key]] = null] - The merchant private key(file path string).
+     * @param string [$config[merchant[cert]] = null] - The merchant certificate(file path string).
+     *
+     * @return BuilderChainable - The chainable client
+     */
+    public static function factory(array $config = [])
+    {
+        return new class([], new ClientDecorator($config)) extends ArrayIterator implements BuilderChainable
+        {
+            use BuilderTrait;
+
+            /**
+             * Compose the chainable `ClientDecorator` instance, most starter with the tree root point
+             */
+            public function __construct(array $input = [], ?ClientDecoratorInterface $instance = null) {
+                parent::__construct($input, self::STD_PROP_LIST | self::ARRAY_AS_PROPS);
+
+                $this->setDriver($instance);
+            }
+
+            /**
+             * @var ClientDecoratorInterface $driver - The `ClientDecorator` instance
+             */
+            protected $driver;
+
+            /**
+             * `$driver` setter
+             * @param ClientDecoratorInterface $instance - The `ClientDecorator` instance
+             *
+             * @return BuilderChainable
+             */
+            public function setDriver(ClientDecoratorInterface &$instance)
+            {
+                $this->driver = $instance;
+
+                return $this;
+            }
+
+            /**
+             * @inheritDoc
+             */
+            public function getDriver(): ClientDecoratorInterface
+            {
+                return $this->driver;
+            }
+
+            /**
+             * Normalize the `$thing` by the rules: `PascalCase` -> `camelCase`
+             *                                    & `camelCase` -> `camel-case`
+             *                                    & `_dynamic_` -> `{dynamic}`
+             *
+             * @param string thing - The string waiting for normalization
+             *
+             * @return string
+             */
+            protected function normalize(string $thing = ''): string
+            {
+                return preg_replace('#^_(.*)_$#', '{\1}', preg_replace_callback('#[A-Z]#', static function($piece) {
+                    return '-' . strtolower($piece[0]);
+                }, preg_replace_callback('#^[A-Z]#', static function($piece) {
+                    return strtolower($piece);
+                }, $thing)));
+            }
+
+            /**
+             * URI pathname
+             *
+             * @param string [$seperator = '/'] - The URI seperator
+             *
+             * @return string - The URI string
+             */
+            protected function pathname(string $seperator = '/'): string
+            {
+                return implode($seperator, $this->simplized());
+            }
+
+            /**
+             * Only retrieve a copy array of the URI entities
+             *
+             * @return array - The URI entities' array
+             */
+            protected function simplized(): array
+            {
+                return array_filter($this->getArrayCopy(), static function($v) { return !($v instanceof BuilderChainable); });
+            }
+
+            /**
+             * Chainable the given `$key` with the `ClientDecoratorInterface` instance
+             *
+             * @param string|int $key - The key
+             *
+             * @return BuilderChainable
+             */
+            public function offsetGet($key): BuilderChainable
+            {
+                if (!$this->offsetExists($key)) {
+                  $index = $this->simplized();
+                  array_push($index, $this->normalize($key));
+                  $this->offsetSet($key, new self($index, $this->getDriver()));
+                }
+
+                return parent::offsetGet($key);
+            }
+        };
+    }
+
+    private function __construct()
+    {
+        // cannot be instantiated
+    }
+}

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -19,6 +19,16 @@ final class Builder
     /**
      * Building & decorate the chainable `GuzzleHttp\Client`
      *
+     * Minimum mandatory \$config parameters structure
+     *   - mchid: string - The merchant ID
+     *   - serial: string - The serial number of the merchant certificate
+     *   - privateKey: \OpenSSLAsymmetricKey|\OpenSSLCertificate|resource|array|string - The merchant private key.
+     *   - certs: array<string, \OpenSSLAsymmetricKey|\OpenSSLCertificate|resource|array|string> - The wechatpay platform serial and certificate(s)
+     *   - secret?: string - The secret key string (optional)
+     *   - merchant?: array{key?: string, cert?: string} - The merchant private key and certificate array. (optional)
+     *   - merchant<?key, string> - The merchant private key(file path string). (optional)
+     *   - merchant<?cert, string> - The merchant certificate(file path string). (optional)
+     *
      * ```php
      * // usage samples
      * $instance = Builder::factory([]);
@@ -28,15 +38,7 @@ final class Builder
      * $instance->v3->certificates->getAsync()->then(function() {})->otherwise(function() {})->wait();
      * ```
      *
-     * Acceptable \$config parameters stucture
-     *   - mchid: string - The merchant ID
-     *   - serial: string - The serial number of the merchant certificate
-     *   - privateKey: \OpenSSLAsymmetricKey|\OpenSSLCertificate|resource|array|string - The merchant private key.
-     *   - certs: array<string, \OpenSSLAsymmetricKey|\OpenSSLCertificate|resource|array|string> - The wechatpay platform serial and certificate(s)
-     *   - secret?: string - The secret key string (optional)
-     *   - merchant?: array{key?: string, cert?: string} - The merchant private key and certificate array. (optional)
-     *   - merchant<?key, string> - The merchant private key(file path string). (optional)
-     *   - merchant<?cert, string> - The merchant certificate(file path string). (optional)
+     * @param array $config - `\GuzzleHttp\Client`, `APIv3` and `APIv2` configuration settings.
      *
      * @return BuilderChainable - The chainable client
      */

--- a/src/BuilderChainable.php
+++ b/src/BuilderChainable.php
@@ -4,6 +4,9 @@ namespace WeChatPay;
 
 use ArrayAccess;
 
+use GuzzleHttp\Promise\PromiseInterface;
+use Psr\Http\Message\ResponseInterface;
+
 /**
  * Signature of the Chainable `GuzzleHttp\Client` interface
  */
@@ -24,4 +27,74 @@ interface BuilderChainable extends ArrayAccess
      * @return BuilderChainable
      */
     public function offsetGet($key): BuilderChainable;
+
+    /**
+     * Create and send an HTTP GET request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function get(array $options = []): ResponseInterface;
+
+    /**
+     * Create and send an HTTP PUT request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function put(array $options = []): ResponseInterface;
+
+    /**
+     * Create and send an HTTP POST request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function post(array $options = []): ResponseInterface;
+
+    /**
+     * Create and send an HTTP PATCH request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function patch(array $options = []): ResponseInterface;
+
+    /**
+     * Create and send an HTTP DELETE request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function delete(array $options = []): ResponseInterface;
+
+    /**
+     * Create and send an asynchronous HTTP GET request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function getAsync(array $options = []): PromiseInterface;
+
+    /**
+     * Create and send an asynchronous HTTP PUT request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function putAsync(array $options = []): PromiseInterface;
+
+    /**
+     * Create and send an asynchronous HTTP POST request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function postAsync(array $options = []): PromiseInterface;
+
+    /**
+     * Create and send an asynchronous HTTP PATCH request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function patchAsync(array $options = []): PromiseInterface;
+
+    /**
+     * Create and send an asynchronous HTTP DELETE request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function deleteAsync(array $options = []): PromiseInterface;
 }

--- a/src/BuilderChainable.php
+++ b/src/BuilderChainable.php
@@ -2,15 +2,13 @@
 
 namespace WeChatPay;
 
-use ArrayAccess;
-
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
  * Signature of the Chainable `GuzzleHttp\Client` interface
  */
-interface BuilderChainable extends ArrayAccess
+interface BuilderChainable
 {
     /**
      * `$driver` getter

--- a/src/BuilderChainable.php
+++ b/src/BuilderChainable.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace WeChatPay;
+
+use ArrayAccess;
+
+/**
+ * Signature of the Chainable `GuzzleHttp\Client` interface
+ */
+interface BuilderChainable extends ArrayAccess
+{
+    /**
+     * `$driver` getter
+     *
+     * @return ClientDecoratorInterface - The `ClientDecorator` instance
+     */
+    public function getDriver(): ClientDecoratorInterface;
+
+    /**
+     * Chainable the given `$key` with the `ClientDecoratorInterface` instance
+     *
+     * @param string|int $key - The key
+     *
+     * @return BuilderChainable
+     */
+    public function offsetGet($key): BuilderChainable;
+}

--- a/src/BuilderChainable.php
+++ b/src/BuilderChainable.php
@@ -18,13 +18,13 @@ interface BuilderChainable
     public function getDriver(): ClientDecoratorInterface;
 
     /**
-     * Chainable the given `$key` with the `ClientDecoratorInterface` instance
+     * Chainable the given `$segment` with the `ClientDecoratorInterface` instance
      *
-     * @param string|int $key - The key
+     * @param string|int $segment - The sgement or `URI`
      *
      * @return BuilderChainable
      */
-    public function offsetGet($key): BuilderChainable;
+    public function chain($segment): BuilderChainable;
 
     /**
      * Create and send an HTTP GET request.

--- a/src/BuilderTrait.php
+++ b/src/BuilderTrait.php
@@ -10,6 +10,8 @@ use Psr\Http\Message\ResponseInterface;
  */
 trait BuilderTrait
 {
+    abstract public function getDriver(): ClientDecoratorInterface;
+
     /**
      * URI pathname
      *

--- a/src/BuilderTrait.php
+++ b/src/BuilderTrait.php
@@ -13,7 +13,7 @@ trait BuilderTrait
     /**
      * URI pathname
      *
-     * @param string [$seperator = '/'] - The URI seperator
+     * @param string $seperator - The URI seperator, default is slash(`/`) character
      *
      * @return string - The URI string
      */

--- a/src/BuilderTrait.php
+++ b/src/BuilderTrait.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace WeChatPay;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Chainable points the client interface for sending HTTP requests.
+ */
+trait BuilderTrait
+{
+    /**
+     * URI pathname
+     *
+     * @param string [$seperator = '/'] - The URI seperator
+     *
+     * @return string - The URI string
+     */
+    abstract protected function pathname(string $seperator = '/'): string;
+
+    /**
+     * Create and send an HTTP GET request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function get(array $options = []): ResponseInterface
+    {
+        return $this->getDriver()->request('GET', $this->pathname(), $options);
+    }
+
+    /**
+     * Create and send an HTTP PUT request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function put(array $options = []): ResponseInterface
+    {
+        return $this->getDriver()->request('PUT', $this->pathname(), $options);
+    }
+
+    /**
+     * Create and send an HTTP POST request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function post(array $options = []): ResponseInterface
+    {
+        return $this->getDriver()->request('POST', $this->pathname(), $options);
+    }
+
+    /**
+     * Create and send an HTTP PATCH request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function patch(array $options = []): ResponseInterface
+    {
+        return $this->getDriver()->request('PATCH', $this->pathname(), $options);
+    }
+
+    /**
+     * Create and send an HTTP DELETE request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function delete(array $options = []): ResponseInterface
+    {
+        return $this->getDriver()->request('DELETE', $this->pathname(), $options);
+    }
+
+    /**
+     * Create and send an asynchronous HTTP GET request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function getAsync(array $options = []): PromiseInterface
+    {
+        return $this->getDriver()->requestAsync('GET', $this->pathname(), $options);
+    }
+
+    /**
+     * Create and send an asynchronous HTTP PUT request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function putAsync(array $options = []): PromiseInterface
+    {
+        return $this->getDriver()->requestAsync('PUT', $this->pathname(), $options);
+    }
+
+    /**
+     * Create and send an asynchronous HTTP POST request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function postAsync(array $options = []): PromiseInterface
+    {
+        return $this->getDriver()->requestAsync('POST', $this->pathname(), $options);
+    }
+
+    /**
+     * Create and send an asynchronous HTTP PATCH request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function patchAsync(array $options = []): PromiseInterface
+    {
+        return $this->getDriver()->requestAsync('PATCH', $this->pathname(), $options);
+    }
+
+    /**
+     * Create and send an asynchronous HTTP DELETE request.
+     *
+     * @param array $options Request options to apply.
+     */
+    public function deleteAsync(array $options = []): PromiseInterface
+    {
+        return $this->getDriver()->requestAsync('DELETE', $this->pathname(), $options);
+    }
+}

--- a/src/BuilderTrait.php
+++ b/src/BuilderTrait.php
@@ -20,9 +20,7 @@ trait BuilderTrait
     abstract protected function pathname(string $seperator = '/'): string;
 
     /**
-     * Create and send an HTTP GET request.
-     *
-     * @param array $options Request options to apply.
+     * @inheritDoc
      */
     public function get(array $options = []): ResponseInterface
     {
@@ -30,9 +28,7 @@ trait BuilderTrait
     }
 
     /**
-     * Create and send an HTTP PUT request.
-     *
-     * @param array $options Request options to apply.
+     * @inheritDoc
      */
     public function put(array $options = []): ResponseInterface
     {
@@ -40,9 +36,7 @@ trait BuilderTrait
     }
 
     /**
-     * Create and send an HTTP POST request.
-     *
-     * @param array $options Request options to apply.
+     * @inheritDoc
      */
     public function post(array $options = []): ResponseInterface
     {
@@ -50,9 +44,7 @@ trait BuilderTrait
     }
 
     /**
-     * Create and send an HTTP PATCH request.
-     *
-     * @param array $options Request options to apply.
+     * @inheritDoc
      */
     public function patch(array $options = []): ResponseInterface
     {
@@ -60,9 +52,7 @@ trait BuilderTrait
     }
 
     /**
-     * Create and send an HTTP DELETE request.
-     *
-     * @param array $options Request options to apply.
+     * @inheritDoc
      */
     public function delete(array $options = []): ResponseInterface
     {
@@ -70,9 +60,7 @@ trait BuilderTrait
     }
 
     /**
-     * Create and send an asynchronous HTTP GET request.
-     *
-     * @param array $options Request options to apply.
+     * @inheritDoc
      */
     public function getAsync(array $options = []): PromiseInterface
     {
@@ -80,9 +68,7 @@ trait BuilderTrait
     }
 
     /**
-     * Create and send an asynchronous HTTP PUT request.
-     *
-     * @param array $options Request options to apply.
+     * @inheritDoc
      */
     public function putAsync(array $options = []): PromiseInterface
     {
@@ -90,9 +76,7 @@ trait BuilderTrait
     }
 
     /**
-     * Create and send an asynchronous HTTP POST request.
-     *
-     * @param array $options Request options to apply.
+     * @inheritDoc
      */
     public function postAsync(array $options = []): PromiseInterface
     {
@@ -100,9 +84,7 @@ trait BuilderTrait
     }
 
     /**
-     * Create and send an asynchronous HTTP PATCH request.
-     *
-     * @param array $options Request options to apply.
+     * @inheritDoc
      */
     public function patchAsync(array $options = []): PromiseInterface
     {
@@ -110,9 +92,7 @@ trait BuilderTrait
     }
 
     /**
-     * Create and send an asynchronous HTTP DELETE request.
-     *
-     * @param array $options Request options to apply.
+     * @inheritDoc
      */
     public function deleteAsync(array $options = []): PromiseInterface
     {

--- a/src/ClientDecorator.php
+++ b/src/ClientDecorator.php
@@ -93,7 +93,7 @@ final class ClientDecorator implements ClientDecoratorInterface
      *   - merchant<?key, string> - The merchant private key(file path string). (optional)
      *   - merchant<?cert, string> - The merchant certificate(file path string). (optional)
      *
-     * @return ClientDecorator - The `ClientDecorator` instance
+     * @param array $config - `\GuzzleHttp\Client`, `APIv3` and `APIv2` configuration settings.
      */
     public function __construct(array $config = [])
     {
@@ -135,7 +135,7 @@ final class ClientDecorator implements ClientDecoratorInterface
     */
     protected static function withUriTemplate(string $template, array $variables = []): string
     {
-        if (0 === preg_match('#{(?:[^/]+)}#', $template)) {
+        if (0 === preg_match('#\{(?:[^/]+)\}#', $template)) {
             return $template;
         }
 

--- a/src/ClientDecorator.php
+++ b/src/ClientDecorator.php
@@ -81,15 +81,15 @@ final class ClientDecorator implements ClientDecoratorInterface
     /**
      * Decorate the `GuzzleHttp\Client` factory
      *
-     * @param array $config - configuration
-     * @param string|int $config[mchid] - The merchant ID
-     * @param string $config[serial] - The serial number of the merchant certificate
-     * @param OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string $config[privateKey] - The merchant private key.
-     * @param array $config[certs] - The WeChatPay platform serial and certificate(s), `[serial => certificate]` pair
-     * @param string [$config[secret] = null] - The secret key string
-     * @param array [$config[merchant] = null] - The merchant private key and certificate array
-     * @param string [$config[merchant[key]] = null] - The merchant private key(file path string).
-     * @param string [$config[merchant[cert]] = null] - The merchant certificate(file path string).
+     * Acceptable \$config parameters stucture
+     *   - mchid: string - The merchant ID
+     *   - serial: string - The serial number of the merchant certificate
+     *   - privateKey: \OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string - The merchant private key.
+     *   - certs: [$key:string => $value: mixed] - The wechatpay platform serial and certificate(s)
+     *   - secret: ?string - The secret key string (optional)
+     *   - merchant: ?array - The merchant private key and certificate array (optional)
+     *   - merchant<key: ?string> - The merchant private key(file path string). (optional)
+     *   - merchant<cert: ?string> - The merchant certificate(file path string). (optional)
      *
      * @return ClientDecorator - The `ClientDecorator` instance
      */

--- a/src/ClientDecorator.php
+++ b/src/ClientDecorator.php
@@ -13,7 +13,6 @@ use function preg_match;
 use function strncasecmp;
 use function strcasecmp;
 use function preg_replace;
-use function strtoupper;
 
 use const PHP_OS;
 use const PHP_VERSION;
@@ -25,7 +24,7 @@ use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * Decorate the `\GuzzleHttp\Client` instance
+ * Decorate the `GuzzleHttp\Client` instance
  */
 final class ClientDecorator implements ClientDecoratorInterface
 {
@@ -87,6 +86,10 @@ final class ClientDecorator implements ClientDecoratorInterface
      * @param string $config[serial] - The serial number of the merchant certificate
      * @param OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string $config[privateKey] - The merchant private key.
      * @param array $config[certs] - The WeChatPay platform serial and certificate(s), `[serial => certificate]` pair
+     * @param string [$config[secret] = null] - The secret key string
+     * @param array [$config[merchant] = null] - The merchant private key and certificate array
+     * @param string [$config[merchant[key]] = null] - The merchant private key(file path string).
+     * @param string [$config[merchant[cert]] = null] - The merchant certificate(file path string).
      *
      * @return ClientDecorator - The `ClientDecorator` instance
      */
@@ -129,7 +132,7 @@ final class ClientDecorator implements ClientDecoratorInterface
      *
      * @return string
     */
-    protected function withUriTemplate(string $template, array $variables = []): string
+    protected static function withUriTemplate(string $template, array $variables = []): string
     {
         if (0 === preg_match('#{(?:[^/]+)}#', $template)) {
             return $template;
@@ -154,9 +157,9 @@ final class ClientDecorator implements ClientDecoratorInterface
      */
     public function request(string $method, string $uri, array $options = []): ResponseInterface
     {
-        $did = static::prepare($uri);
+        list($protocol, $pathname) = static::prepare($uri);
 
-        return $this->select($did[0])->request(strtoupper($method), $this->withUriTemplate($did[1], $options), $options);
+        return $this->select($protocol)->request($method, static::withUriTemplate($pathname, $options), $options);
     }
 
     /**
@@ -164,8 +167,8 @@ final class ClientDecorator implements ClientDecoratorInterface
      */
     public function requestAsync(string $method, string $uri, array $options = []): PromiseInterface
     {
-        $did = static::prepare($uri);
+        list($protocol, $pathname) = static::prepare($uri);
 
-        return $this->select($did[0])->requestAsync(strtoupper($method), $this->withUriTemplate($did[1], $options), $options);
+        return $this->select($protocol)->requestAsync($method, static::withUriTemplate($pathname, $options), $options);
     }
 }

--- a/src/ClientDecorator.php
+++ b/src/ClientDecorator.php
@@ -12,7 +12,7 @@ use function implode;
 use function preg_match;
 use function strncasecmp;
 use function strcasecmp;
-use function preg_replace;
+use function substr;
 
 use const PHP_OS;
 use const PHP_VERSION;
@@ -110,7 +110,7 @@ final class ClientDecorator implements ClientDecoratorInterface
      */
     private static function prepare(string $uri): array
     {
-        return 0 === strncasecmp(ClientDecoratorInterface::XML_BASED . '/', $uri, 3)
+        return $uri && 0 === strncasecmp(ClientDecoratorInterface::XML_BASED . '/', $uri, 3)
             ? [ClientDecoratorInterface::XML_BASED, substr($uri, 3)]
             : [ClientDecoratorInterface::JSON_BASED, $uri];
     }
@@ -139,7 +139,7 @@ final class ClientDecorator implements ClientDecoratorInterface
             return $template;
         }
 
-        if (extension_loaded('uri_template')) {
+        if (extension_loaded('uri_template') && function_exists('uri_template')) {
             // @codeCoverageIgnoreStart
             return \uri_template($template, $variables);
             // @codeCoverageIgnoreEnd

--- a/src/ClientDecorator.php
+++ b/src/ClientDecorator.php
@@ -139,12 +139,6 @@ final class ClientDecorator implements ClientDecoratorInterface
             return $template;
         }
 
-        if (extension_loaded('uri_template') && function_exists('uri_template')) {
-            // @codeCoverageIgnoreStart
-            return \uri_template($template, $variables);
-            // @codeCoverageIgnoreEnd
-        }
-
         static $uriTemplate;
         if (!$uriTemplate) {
             $uriTemplate = new UriTemplate();

--- a/src/ClientDecorator.php
+++ b/src/ClientDecorator.php
@@ -49,7 +49,7 @@ final class ClientDecorator implements ClientDecoratorInterface
      */
     protected static function userAgent(): array
     {
-        $value = ['WechatPay-Guzzle/' . static::VERSION];
+        $value = ['wechatpay-php/' . static::VERSION];
 
         array_push($value, 'GuzzleHttp/' . ClientInterface::MAJOR_VERSION);
 

--- a/src/ClientDecorator.php
+++ b/src/ClientDecorator.php
@@ -100,18 +100,17 @@ final class ClientDecorator implements ClientDecoratorInterface
     }
 
     /**
-     * Identify the `Client` and `uri`
+     * Identify the `protocol` and `uri`
      *
      * @param string $uri - The uri string.
      *
-     * @return array - the first element is the client instance, the second is the real uri
+     * @return array - the first element is the API version ask `protocol`, the second is the real `uri`
      */
     private static function prepare(string $uri): array
     {
-        return [0 === strncasecmp(ClientDecoratorInterface::XML_BASED . '/', $uri, 3)
-            ? ClientDecoratorInterface::XML_BASED
-            : ClientDecoratorInterface::JSON_BASED,
-            preg_replace('#^' . ClientDecoratorInterface::XML_BASED . '/#i', '', $uri)];
+        return 0 === strncasecmp(ClientDecoratorInterface::XML_BASED . '/', $uri, 3)
+            ? [ClientDecoratorInterface::XML_BASED, substr($uri, 3)]
+            : [ClientDecoratorInterface::JSON_BASED, $uri];
     }
 
     /**

--- a/src/ClientDecorator.php
+++ b/src/ClientDecorator.php
@@ -36,7 +36,7 @@ final class ClientDecorator implements ClientDecoratorInterface
      *
      * @param array $config - The configuration.
      *
-     * @return array - With the built-in configuration.
+     * @return array<string, string|mixed> - With the built-in configuration.
      */
     protected static function withDefaults(array $config = []): array
     {
@@ -45,6 +45,8 @@ final class ClientDecorator implements ClientDecoratorInterface
 
     /**
      * Prepare the `User-Agent` value key/value pair
+     *
+     * @return array<string, string>
      */
     protected static function userAgent(): array
     {
@@ -84,12 +86,12 @@ final class ClientDecorator implements ClientDecoratorInterface
      * Acceptable \$config parameters stucture
      *   - mchid: string - The merchant ID
      *   - serial: string - The serial number of the merchant certificate
-     *   - privateKey: \OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string - The merchant private key.
-     *   - certs: [$key:string => $value: mixed] - The wechatpay platform serial and certificate(s)
-     *   - secret: ?string - The secret key string (optional)
-     *   - merchant: ?array - The merchant private key and certificate array (optional)
-     *   - merchant<key: ?string> - The merchant private key(file path string). (optional)
-     *   - merchant<cert: ?string> - The merchant certificate(file path string). (optional)
+     *   - privateKey: \OpenSSLAsymmetricKey|\OpenSSLCertificate|resource|array|string - The merchant private key.
+     *   - certs: array<string, \OpenSSLAsymmetricKey|\OpenSSLCertificate|resource|array|string> - The wechatpay platform serial and certificate(s)
+     *   - secret?: string - The secret key string (optional)
+     *   - merchant?: array{key?: string, cert?: string} - The merchant private key and certificate array. (optional)
+     *   - merchant<?key, string> - The merchant private key(file path string). (optional)
+     *   - merchant<?cert, string> - The merchant certificate(file path string). (optional)
      *
      * @return ClientDecorator - The `ClientDecorator` instance
      */
@@ -104,7 +106,7 @@ final class ClientDecorator implements ClientDecoratorInterface
      *
      * @param string $uri - The uri string.
      *
-     * @return array - the first element is the API version ask `protocol`, the second is the real `uri`
+     * @return array<string> - the first element is the API version ask `protocol`, the second is the real `uri`
      */
     private static function prepare(string $uri): array
     {
@@ -127,7 +129,7 @@ final class ClientDecorator implements ClientDecoratorInterface
      * Expands a URI template
      *
      * @param string $template  URI template
-     * @param array  $variables Template variables
+     * @param array<string|int,string|int> $variables Template variables
      *
      * @return string
     */

--- a/src/ClientDecorator.php
+++ b/src/ClientDecorator.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace WeChatPay;
+
+use function array_replace_recursive;
+use function array_push;
+use function extension_loaded;
+use function function_exists;
+use function sprintf;
+use function php_uname;
+use function implode;
+use function preg_match;
+use function strncasecmp;
+use function strcasecmp;
+use function preg_replace;
+use function strtoupper;
+
+use const PHP_OS;
+use const PHP_VERSION;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\UriTemplate\UriTemplate;
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Decorate the `\GuzzleHttp\Client` instance
+ */
+final class ClientDecorator implements ClientDecoratorInterface
+{
+    use ClientXmlTrait;
+    use ClientJsonTrait;
+
+    /**
+     * Deep merge the input with the defaults
+     *
+     * @param array $config - The configuration.
+     *
+     * @return array - With the built-in configuration.
+     */
+    protected static function withDefaults(array $config = []): array
+    {
+        return array_replace_recursive(static::$defaults, ['headers' => static::userAgent()], $config);
+    }
+
+    /**
+     * Prepare the `User-Agent` value key/value pair
+     */
+    protected static function userAgent(): array
+    {
+        $value = ['WechatPay-Guzzle/' . static::VERSION];
+
+        array_push($value, 'GuzzleHttp/' . ClientInterface::MAJOR_VERSION);
+
+        extension_loaded('curl') && function_exists('curl_version') && array_push($value, 'curl/' . curl_version()['version']);
+
+        array_push($value, sprintf('(%s/%s) PHP/%s', PHP_OS, php_uname('r'), PHP_VERSION));
+
+        return ['User-Agent' => implode(' ', $value)];
+    }
+
+    /**
+     * Taken body string
+     *
+     * @param MessageInterface $message - The message
+     *
+     * @return string
+     */
+    protected static function body(MessageInterface $message): string
+    {
+        $body = '';
+        $bodyStream = $message->getBody();
+        if ($bodyStream->isSeekable()) {
+            $body = (string)$bodyStream;
+            $bodyStream->rewind();
+        }
+
+        return $body;
+    }
+
+    /**
+     * Decorate the `GuzzleHttp\Client` factory
+     *
+     * @param array $config - configuration
+     * @param string|int $config[mchid] - The merchant ID
+     * @param string $config[serial] - The serial number of the merchant certificate
+     * @param OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string $config[privateKey] - The merchant private key.
+     * @param array $config[certs] - The WeChatPay platform serial and certificate(s), `[serial => certificate]` pair
+     *
+     * @return ClientDecorator - The `ClientDecorator` instance
+     */
+    public function __construct(array $config = [])
+    {
+        $this->{ClientDecoratorInterface::XML_BASED} = static::xmlBased($config);
+        $this->{ClientDecoratorInterface::JSON_BASED} = static::jsonBased($config);
+    }
+
+    /**
+     * Identify the `Client` and `uri`
+     *
+     * @param string $uri - The uri string.
+     *
+     * @return array - the first element is the client instance, the second is the real uri
+     */
+    private static function prepare(string $uri): array
+    {
+        return [0 === strncasecmp(ClientDecoratorInterface::XML_BASED . '/', $uri, 3)
+            ? ClientDecoratorInterface::XML_BASED
+            : ClientDecoratorInterface::JSON_BASED,
+            preg_replace('#^' . ClientDecoratorInterface::XML_BASED . '/#i', '', $uri)];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function select(?string $protocol = null): ClientInterface
+    {
+        return $protocol && 0 === strcasecmp(ClientDecoratorInterface::XML_BASED, $protocol)
+            ? $this->{ClientDecoratorInterface::XML_BASED}
+            : $this->{ClientDecoratorInterface::JSON_BASED};
+    }
+
+    /**
+     * Expands a URI template
+     *
+     * @param string $template  URI template
+     * @param array  $variables Template variables
+     *
+     * @return string
+    */
+    protected function withUriTemplate(string $template, array $variables = []): string
+    {
+        if (0 === preg_match('#{(?:[^/]+)}#', $template)) {
+            return $template;
+        }
+
+        if (extension_loaded('uri_template')) {
+            // @codeCoverageIgnoreStart
+            return \uri_template($template, $variables);
+            // @codeCoverageIgnoreEnd
+        }
+
+        static $uriTemplate;
+        if (!$uriTemplate) {
+            $uriTemplate = new UriTemplate();
+        }
+
+        return $uriTemplate->expand($template, $variables);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function request(string $method, string $uri, array $options = []): ResponseInterface
+    {
+        $did = static::prepare($uri);
+
+        return $this->select($did[0])->request(strtoupper($method), $this->withUriTemplate($did[1], $options), $options);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function requestAsync(string $method, string $uri, array $options = []): PromiseInterface
+    {
+        $did = static::prepare($uri);
+
+        return $this->select($did[0])->requestAsync(strtoupper($method), $this->withUriTemplate($did[1], $options), $options);
+    }
+}

--- a/src/ClientDecoratorInterface.php
+++ b/src/ClientDecoratorInterface.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace WeChatPay;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Promise\PromiseInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Decorate the `GuzzleHttp\Client` interface
+ */
+interface ClientDecoratorInterface
+{
+    /**
+     * @var string - This library version
+     */
+    const VERSION = '1.0.0';
+
+    /**
+     * @var string - The HTTP transfer `xml` based protocol
+     */
+    const XML_BASED = 'v2';
+
+    /**
+     * @var string - The HTTP transfer `json` based protocol
+     */
+    const JSON_BASED = 'v3';
+
+    /**
+     * Protocol selector
+     *
+     * @param string|null $protocol - one of the constants of `XML_BASED`, `JSON_BASED`, default is `JSON_BASED`
+     * @return ClientInterface
+     */
+    public function select(?string $protocol = null): ClientInterface;
+
+    /**
+     * Request the remote `$uri` by a HTTP `$method` verb
+     *
+     * @param string $uri - The uri string.
+     * @param string $method - The method string.
+     * @param array $options - The options.
+     *
+     * @return ResponseInterface - The `Psr\Http\Message\ResponseInterface` instance
+     */
+    public function request(string $method, string $uri, array $options = []): ResponseInterface;
+
+    /**
+     * Async request the remote `$uri` by a HTTP `$method` verb
+     *
+     * @param string $uri - The uri string.
+     * @param string $method - The method string.
+     * @param array $options - The options.
+     *
+     * @return PromiseInterface - The `GuzzleHttp\Promise\PromiseInterface` instance
+     */
+    public function requestAsync(string $method, string $uri, array $options = []): PromiseInterface;
+}

--- a/src/ClientJsonTrait.php
+++ b/src/ClientJsonTrait.php
@@ -19,6 +19,7 @@ use GuzzleHttp\Middleware;
 use GuzzleHttp\HandlerStack;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\MessageInterface;
 
 /** @var int - The maximum clock offset in second */
 const MAXIMUM_CLOCK_OFFSET = 301;
@@ -49,13 +50,8 @@ trait ClientJsonTrait
         ],
     ];
 
-    /**
-     * Deep merge the input with the defaults
-     *
-     * @param array $config - The configuration.
-     *
-     * @return array - With the built-in configuration.
-     */
+    abstract protected static function body(MessageInterface $message): string;
+
     abstract protected static function withDefaults(array $config = []): array;
 
     /**

--- a/src/ClientJsonTrait.php
+++ b/src/ClientJsonTrait.php
@@ -39,7 +39,7 @@ trait ClientJsonTrait
     protected $v3;
 
     /**
-     * @var array - The defaults configuration whose pased in `GuzzleHttp\Client`.
+     * @var array<string, string|array<string, string>> - The defaults configuration whose pased in `GuzzleHttp\Client`.
      */
     protected static $defaults = [
         'base_uri' => 'https://api.mch.weixin.qq.com/',
@@ -86,7 +86,7 @@ trait ClientJsonTrait
     /**
      * APIv3's verifier middleware stack
      *
-     * @param array $certs The wechatpay platform serial and certificate(s), `[serial => certificate]` pair
+     * @param array<string, \OpenSSLAsymmetricKey|\OpenSSLCertificate|resource|array|string> $certs The wechatpay platform serial and certificate(s), `[serial => certificate]` pair
      *
      * @return callable
      * @throws InvalidArgumentException
@@ -130,8 +130,8 @@ trait ClientJsonTrait
      * Mandatory \$config array paramters
      *   - mchid: string - The merchant ID
      *   - serial: string - The serial number of the merchant certificate
-     *   - privateKey: mixed - The merchant private key.
-     *   - certs: [$key:string => $value: mixed] - The wechatpay platform serial and certificate(s)
+     *   - privateKey: \OpenSSLAsymmetricKey|\OpenSSLCertificate|resource|array|string - The merchant private key.
+     *   - certs: array{string, \OpenSSLAsymmetricKey|\OpenSSLCertificate|resource|array|string} - The wechatpay platform serial and certificate(s)
      *
      * @return Client - The `GuzzleHttp\Client` instance
      * @throws InvalidArgumentException

--- a/src/ClientJsonTrait.php
+++ b/src/ClientJsonTrait.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace WeChatPay;
+
+use function assert;
+use function abs;
+use function intval;
+use function is_string;
+use function is_numeric;
+use function is_resource;
+use function is_object;
+use function is_array;
+use function count;
+
+use InvalidArgumentException;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\HandlerStack;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/** @var int - The maximum clock offset in second */
+const MAXIMUM_CLOCK_OFFSET = 301;
+
+const WechatpayNonce = 'Wechatpay-Nonce';
+const WechatpaySerial = 'Wechatpay-Serial';
+const WechatpaySignature = 'Wechatpay-Signature';
+const WechatpayTimestamp = 'Wechatpay-Timestamp';
+
+/**
+ * JSON based Client interface for sending HTTP requests.
+ */
+trait ClientJsonTrait
+{
+    /**
+     * @var Client - The APIv3's `GuzzleHttp\Client`
+     */
+    protected $v3;
+
+    /**
+     * @var array - The defaults configuration whose pased in `GuzzleHttp\Client`.
+     */
+    protected static $defaults = [
+        'base_uri' => 'https://api.mch.weixin.qq.com/',
+        'headers' => [
+            'Accept' => 'application/json, text/plain, application/x-gzip',
+            'Content-Type' => 'application/json; charset=utf-8',
+        ],
+    ];
+
+    /**
+     * Deep merge the input with the defaults
+     *
+     * @param array $config - The configuration.
+     *
+     * @return array - With the built-in configuration.
+     */
+    abstract protected static function withDefaults(array $config = []): array;
+
+    /**
+     * APIv3's signer middleware stack
+     *
+     * @param string|int $mchid - The merchant ID
+     * @param string $serial - The serial number of the merchant certificate
+     * @param OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string $privateKey - The merchant private key.
+     *
+     * @return callable
+     * @throws InvalidArgumentException
+     */
+    public static function signer(string $mchid, string $serial, $privateKey): callable
+    {
+        return static function (RequestInterface $request) use ($mchid, $serial, $privateKey): RequestInterface {
+            $nonce = Formatter::nonce();
+            $timestamp = (string) Formatter::timestamp();
+            $signature = Crypto\Rsa::sign(Formatter::request(
+                $request->getMethod(), $request->getRequestTarget(), $timestamp, $nonce, static::body($request)
+            ), $privateKey);
+
+            return $request->withHeader('Authorization', Formatter::authorization(
+                $mchid, $nonce, $signature, $timestamp, $serial
+            ));
+        };
+    }
+
+    /**
+     * APIv3's verifier middleware stack
+     *
+     * @param array $certs The wechatpay platform serial and certificate(s), `[serial => certificate]` pair
+     *
+     * @return callable
+     * @throws InvalidArgumentException
+     */
+    public static function verifier(array &$certs): callable
+    {
+        return static function (ResponseInterface $response) use (&$certs): ResponseInterface {
+            assert($response->hasHeader(WechatpayNonce) && $response->hasHeader(WechatpaySerial)
+                && $response->hasHeader(WechatpaySignature) && $response->hasHeader(WechatpayTimestamp),
+                new InvalidArgumentException('The response\'s Headers incomplete.')
+            );
+
+            list($nonce) = $response->getHeader(WechatpayNonce);
+            list($serial) = $response->getHeader(WechatpaySerial);
+            list($signature) = $response->getHeader(WechatpaySignature);
+            list($timestamp) = $response->getHeader(WechatpayTimestamp);
+
+            $localTimestamp = Formatter::timestamp();
+
+            assert(
+                abs($localTimestamp - intval($timestamp)) < MAXIMUM_CLOCK_OFFSET,
+                new InvalidArgumentException(
+                    "It's allowed time offset in ± 5 minutes, the response was on ${timestamp}, your's localtime on ${localTimestamp}."
+                )
+            );
+
+            assert(
+                Crypto\Rsa::verify(Formatter::response($timestamp, $nonce, static::body($response)), $signature, $certs[$serial]),
+                new InvalidArgumentException(
+                    "Verify the response's data with: timestamp=${timestamp}, nonce=${nonce}, signature=${signature}, cert=[${serial}: publicKey] failed."
+                )
+            );
+
+            return $response;
+        };
+    }
+
+    /**
+     * Create an APIv3's client
+     *
+     * @param array $config - configuration
+     * @param string|int $config[mchid] - The merchant ID
+     * @param string $config[serial] - The serial number of the merchant certificate
+     * @param OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string $config[privateKey] - The merchant private key.
+     * @param array $config[certs] - The wechatpay platform serial and certificate(s), `[serial => certificate]` pair
+     *
+     * @return Client - The `GuzzleHttp\Client` instance
+     * @throws InvalidArgumentException
+     */
+    public static function jsonBased(array $config = []): Client
+    {
+        assert(
+            isset($config['mchid']) && (is_string($config['mchid']) || is_numeric($config['mchid'])),
+            new InvalidArgumentException('The merchant\' ID aka `mchid` is required, usually numerical.')
+        );
+
+        assert(
+            isset($config['serial']) && is_string($config['serial']),
+            new InvalidArgumentException('The serial number of the merchant\'s certificate aka `serial` is required, usually hexadecial.')
+        );
+
+        assert(
+            isset($config['privateKey']) && (is_string($config['privateKey']) || is_resource($config['privateKey']) || is_object($config['privateKey'])),
+            new InvalidArgumentException('The merchant\'s private key aka `privateKey` is required, usual as pem format.')
+        );
+
+        assert(
+            isset($config['certs']) && is_array($config['certs']) && count($config['certs']),
+            new InvalidArgumentException('The platform certificate(s) aka `certs` is required, paired as of `[serial => certificate]`.')
+        );
+
+        $handler = $config['handler'] ?? HandlerStack::create();
+        $handler->unshift(Middleware::mapRequest(static::signer($config['mchid'], $config['serial'], $config['privateKey'])), 'signer');
+        $handler->unshift(Middleware::mapResponse(static::verifier($config['certs'])), 'verifier');
+        $config['handler'] = $handler;
+
+        unset($config['mchid'], $config['serial'], $config['privateKey'], $config['certs'], $config['secret'], $config['merchant']);
+
+        return new Client(static::withDefaults($config));
+    }
+}

--- a/src/ClientJsonTrait.php
+++ b/src/ClientJsonTrait.php
@@ -61,9 +61,9 @@ trait ClientJsonTrait
     /**
      * APIv3's signer middleware stack
      *
-     * @param string|int $mchid - The merchant ID
+     * @param string $mchid - The merchant ID
      * @param string $serial - The serial number of the merchant certificate
-     * @param OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string $privateKey - The merchant private key.
+     * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|resource|array|string $privateKey - The merchant private key.
      *
      * @return callable
      * @throws InvalidArgumentException
@@ -127,11 +127,11 @@ trait ClientJsonTrait
     /**
      * Create an APIv3's client
      *
-     * @param array $config - configuration
-     * @param string|int $config[mchid] - The merchant ID
-     * @param string $config[serial] - The serial number of the merchant certificate
-     * @param OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string $config[privateKey] - The merchant private key.
-     * @param array $config[certs] - The wechatpay platform serial and certificate(s), `[serial => certificate]` pair
+     * Mandatory \$config array paramters
+     *   - mchid: string - The merchant ID
+     *   - serial: string - The serial number of the merchant certificate
+     *   - privateKey: mixed - The merchant private key.
+     *   - certs: [$key:string => $value: mixed] - The wechatpay platform serial and certificate(s)
      *
      * @return Client - The `GuzzleHttp\Client` instance
      * @throws InvalidArgumentException

--- a/src/ClientXmlTrait.php
+++ b/src/ClientXmlTrait.php
@@ -2,7 +2,6 @@
 
 namespace WeChatPay;
 
-use function assert;
 use function strlen;
 use function array_replace_recursive;
 use function trigger_error;
@@ -51,6 +50,7 @@ trait ClientXmlTrait
      * @param array{cert?: ?string, key?: ?string} $merchant - The merchant private key and certificate array. (optional)
      *
      * @return callable
+     * @throws InvalidArgumentException
      */
     public static function transformRequest(?string $mchid = null, ?string $secret = null, ?array $merchant = null): callable
     {
@@ -60,10 +60,9 @@ trait ClientXmlTrait
             return static function (RequestInterface $request, array $options = []) use ($handler, $mchid, $secret, $merchant) {
                 $data = $options['xml'] ?? [];
 
-                assert(
-                    $mchid === ($data['mch_id'] ?? null),
-                    new InvalidArgumentException("The xml's mch_id({$data['mch_id']}) doesn't matched the init one ({$mchid}).")
-                );
+                if ($mchid && $mchid !== ($data['mch_id'] ?? null)) {
+                    throw new InvalidArgumentException("The xml's mch_id({$data['mch_id']}) doesn't matched the init one ({$mchid}).");
+                }
 
                 $type = $data['sign_type'] ?? Crypto\Hash::ALGO_MD5;
 

--- a/src/ClientXmlTrait.php
+++ b/src/ClientXmlTrait.php
@@ -5,7 +5,6 @@ namespace WeChatPay;
 use function assert;
 use function strlen;
 use function array_replace_recursive;
-use function trigger_error;
 
 use InvalidArgumentException;
 
@@ -52,8 +51,6 @@ trait ClientXmlTrait
      */
     public static function transformRequest(?string $mchid = null, ?string $secret = null, ?array $merchant = null): callable
     {
-        trigger_error('New features are all in `APIv3`, There\'s no reason to continue use this kind protocol since v2.0.', E_USER_DEPRECATED);
-
         return static function (callable $handler) use ($mchid, $secret, $merchant): callable {
             return static function (RequestInterface $request, array $options = []) use ($handler, $mchid, $secret, $merchant) {
                 $data = $options['xml'] ?? [];

--- a/src/ClientXmlTrait.php
+++ b/src/ClientXmlTrait.php
@@ -5,6 +5,9 @@ namespace WeChatPay;
 use function assert;
 use function strlen;
 use function array_replace_recursive;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 use InvalidArgumentException;
 
@@ -52,6 +55,8 @@ trait ClientXmlTrait
     public static function transformRequest(?string $mchid = null, ?string $secret = null, ?array $merchant = null): callable
     {
         return static function (callable $handler) use ($mchid, $secret, $merchant): callable {
+            trigger_error('New features are all in `APIv3`, there\'s no reason to continue use this kind client since v2.0', E_USER_DEPRECATED);
+
             return static function (RequestInterface $request, array $options = []) use ($handler, $mchid, $secret, $merchant) {
                 $data = $options['xml'] ?? [];
 

--- a/src/ClientXmlTrait.php
+++ b/src/ClientXmlTrait.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace WeChatPay;
+
+use function assert;
+use function strlen;
+use function array_replace_recursive;
+
+use InvalidArgumentException;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Utils;
+use GuzzleHttp\Promise as P;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * XML based Client interface for sending HTTP requests.
+ */
+trait ClientXmlTrait
+{
+    /**
+     * @var Client - The APIv2's `GuzzleHttp\Client`
+     */
+    protected $v2;
+
+    /**
+     * @var array - The default headers whose passed in `GuzzleHttp\Client`.
+     */
+    protected static $headers = [
+        'Accept' => 'text/xml, text/plain, application/x-gzip',
+        'Content-Type' => 'text/xml; charset=utf-8',
+    ];
+
+    /**
+     * APIv2's transformRequest, did the `datasign` and `array2xml` together
+     *
+     * @return callable
+     */
+    public static function transformRequest(?string $mchid = null, ?string $secret = null, ?array $merchant = null): callable
+    {
+        return static function (callable $handler) use ($mchid, $secret, $merchant): callable {
+            return static function (RequestInterface $request, array $options = []) use ($handler, $mchid, $secret, $merchant) {
+                $data = $options['xml'] ?? [];
+
+                assert(
+                    $mchid === ($data['mch_id'] ?? null),
+                    new InvalidArgumentException("The xml's mch_id({$data['mch_id']}) doesn't matched the init one ({$mchid}).")
+                );
+
+                $type = $data['sign_type'] ?? Crypto\Hash::ALGO_MD5;
+
+                isset($options['nonceless']) || $data['nonce_str'] = $data['nonce_str'] ?? Formatter::nonce();
+
+                $data['sign'] = Crypto\Hash::sign($type, Formatter::queryStringLike(Formatter::ksort($data)), $secret);
+
+                $modify = ['body' => Transformer::toXml($data)];
+
+                // for security request, it was required the merchant's private_key and certificate
+                if (isset($options['security']) && true === $options['security']) {
+                    // @uses GuzzleHttp\RequestOptions::SSL_KEY
+                    $options['ssl_key'] = $merchant['key'] ?? null;
+                    // @uses GuzzleHttp\RequestOptions::CERT
+                    $options['cert'] = $merchant['cert'] ?? null;
+                }
+
+                unset($options['xml'], $options['nonceless'], $options['security']);
+
+                return $handler(Utils::modifyRequest($request, $modify), $options);
+            };
+        };
+    }
+
+    /**
+     * APIv2's transformResponse, doing the `xml2array` then `verify` the signature job only
+     *
+     * @return callable
+     */
+    public static function transformResponse(?string $secret = null): callable
+    {
+        return static function (callable $handler) use ($secret): callable {
+            return static function (RequestInterface $request, array $options = []) use ($secret, $handler) {
+                $promise = $handler($request, $options);
+
+                return $promise->then(static function(ResponseInterface $response) use ($secret) {
+                    $result = Transformer::toArray(static::body($response));
+
+                    $sign = $result['sign'] ?? null;
+                    $type = $sign && strlen($sign) === 64 ? Crypto\Hash::ALGO_HMAC_SHA256 : Crypto\Hash::ALGO_MD5;
+
+                    if ($sign !== Crypto\Hash::sign($type, Formatter::queryStringLike(Formatter::ksort($result)), $secret)) {
+                        return P\Create::rejectionFor($response);
+                    }
+
+                    return $response;
+                });
+            };
+        };
+    }
+
+    /**
+     * Create an APIv2's client
+     *
+     * @param array $config - configuration
+     * @param string|int $config[mchid] - The merchant ID
+     * @param string $config[secret] - The secret key string
+     * @param array $config[merchant] - The merchant private key and certificate array
+     * @param string $config[merchant[key]] - The merchant private key(file path string).
+     * @param string $config[merchant[cert]] - The merchant certificate(file path string).
+     *
+     * @return Client - The `GuzzleHttp\Client` instance
+     */
+    public static function xmlBased(array $config = []): Client
+    {
+        $handler = $config['handler'] ?? HandlerStack::create();
+        $handler->before('prepare_body', static::transformRequest($config['mchid'] ?? null, $config['secret'] ?? null, $config['merchant'] ?? []), 'transform_request');
+        $handler->before('prepare_body', static::transformResponse($config['secret'] ?? null), 'transform_response');
+        $config['handler'] = $handler;
+        $config['headers'] = array_replace_recursive(static::$headers, $config['headers'] ?? []);
+
+        unset($config['mchid'], $config['serial'], $config['privateKey'], $config['certs'], $config['secret'], $config['merchant']);
+
+        return new Client(static::withDefaults($config));
+    }
+}

--- a/src/ClientXmlTrait.php
+++ b/src/ClientXmlTrait.php
@@ -55,7 +55,7 @@ trait ClientXmlTrait
     public static function transformRequest(?string $mchid = null, ?string $secret = null, ?array $merchant = null): callable
     {
         return static function (callable $handler) use ($mchid, $secret, $merchant): callable {
-            trigger_error('New features are all in `APIv3`, there\'s no reason to continue use this kind client since v2.0', E_USER_DEPRECATED);
+            trigger_error('New features are all in `APIv3`, there\'s no reason to continue use this kind client since v2.0.', E_USER_DEPRECATED);
 
             return static function (RequestInterface $request, array $options = []) use ($handler, $mchid, $secret, $merchant) {
                 $data = $options['xml'] ?? [];

--- a/src/ClientXmlTrait.php
+++ b/src/ClientXmlTrait.php
@@ -102,12 +102,10 @@ trait ClientXmlTrait
     /**
      * Create an APIv2's client
      *
-     * @param array $config - configuration
-     * @param string|int $config[mchid] - The merchant ID
-     * @param string $config[secret] - The secret key string
-     * @param array $config[merchant] - The merchant private key and certificate array
-     * @param string $config[merchant[key]] - The merchant private key(file path string).
-     * @param string $config[merchant[cert]] - The merchant certificate(file path string).
+     * Optional acceptable \$config parameters
+     *   - mchid: ?string - The merchant ID
+     *   - secret: ?string - The secret key string
+     *   - merchant: ?array{key: ?string, cert: ?string}
      *
      * @return Client - The `GuzzleHttp\Client` instance
      */

--- a/src/ClientXmlTrait.php
+++ b/src/ClientXmlTrait.php
@@ -5,6 +5,7 @@ namespace WeChatPay;
 use function assert;
 use function strlen;
 use function array_replace_recursive;
+use function trigger_error;
 
 use InvalidArgumentException;
 
@@ -18,6 +19,8 @@ use Psr\Http\Message\MessageInterface;
 
 /**
  * XML based Client interface for sending HTTP requests.
+ *
+ * @deprecated 2.0 - New features are all in `APIv3`, there's no reason to continue use this kind client since v2.0.
  */
 trait ClientXmlTrait
 {
@@ -49,6 +52,8 @@ trait ClientXmlTrait
      */
     public static function transformRequest(?string $mchid = null, ?string $secret = null, ?array $merchant = null): callable
     {
+        trigger_error('New features are all in `APIv3`, There\'s no reason to continue use this kind protocol since v2.0.', E_USER_DEPRECATED);
+
         return static function (callable $handler) use ($mchid, $secret, $merchant): callable {
             return static function (RequestInterface $request, array $options = []) use ($handler, $mchid, $secret, $merchant) {
                 $data = $options['xml'] ?? [];

--- a/src/ClientXmlTrait.php
+++ b/src/ClientXmlTrait.php
@@ -26,7 +26,7 @@ trait ClientXmlTrait
     protected $v2;
 
     /**
-     * @var array - The default headers whose passed in `GuzzleHttp\Client`.
+     * @var array<string, string> - The default headers whose passed in `GuzzleHttp\Client`.
      */
     protected static $headers = [
         'Accept' => 'text/xml, text/plain, application/x-gzip',

--- a/src/ClientXmlTrait.php
+++ b/src/ClientXmlTrait.php
@@ -14,6 +14,7 @@ use GuzzleHttp\Psr7\Utils;
 use GuzzleHttp\Promise as P;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\MessageInterface;
 
 /**
  * XML based Client interface for sending HTTP requests.
@@ -33,8 +34,16 @@ trait ClientXmlTrait
         'Content-Type' => 'text/xml; charset=utf-8',
     ];
 
+    abstract protected static function body(MessageInterface $message): string;
+
+    abstract protected static function withDefaults(array $config = []): array;
+
     /**
      * APIv2's transformRequest, did the `datasign` and `array2xml` together
+     *
+     * @param ?string $mchid - The merchant ID
+     * @param ?string $secret - The secret key string (optional)
+     * @param array{cert?: ?string, key?: ?string} $merchant - The merchant private key and certificate array. (optional)
      *
      * @return callable
      */
@@ -75,6 +84,8 @@ trait ClientXmlTrait
     /**
      * APIv2's transformResponse, doing the `xml2array` then `verify` the signature job only
      *
+     * @param ?string $secret - The secret key string (optional)
+     *
      * @return callable
      */
     public static function transformResponse(?string $secret = null): callable
@@ -103,9 +114,11 @@ trait ClientXmlTrait
      * Create an APIv2's client
      *
      * Optional acceptable \$config parameters
-     *   - mchid: ?string - The merchant ID
-     *   - secret: ?string - The secret key string
-     *   - merchant: ?array{key: ?string, cert: ?string}
+     *   - mchid?: ?string - The merchant ID
+     *   - secret?: ?string - The secret key string
+     *   - merchant?: array{key?: string, cert?: string} - The merchant private key and certificate array. (optional)
+     *   - merchant<?key, string> - The merchant private key(file path string). (optional)
+     *   - merchant<?cert, string> - The merchant certificate(file path string). (optional)
      *
      * @return Client - The `GuzzleHttp\Client` instance
      */

--- a/src/Crypto/AesEcb.php
+++ b/src/Crypto/AesEcb.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WeChatPay\Crypto;
+
+use function openssl_encrypt;
+use function base64_encode;
+use function openssl_decrypt;
+use function base64_decode;
+
+use const OPENSSL_RAW_DATA;
+
+/**
+ * Aes encrypt/decrypt using `aes-256-ecb` algorithm with pkcs7padding.
+ */
+class AesEcb implements AesInterface
+{
+    /**
+     * @inheritDoc
+     */
+    static public function encrypt(string $plaintext, string $key, string $iv = ''): string
+    {
+        $ciphertext = openssl_encrypt($plaintext, static::ALGO_AES_256_ECB, $key, OPENSSL_RAW_DATA, $iv);
+
+        return base64_encode($ciphertext);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    static public function decrypt(string $ciphertext, string $key, string $iv = ''): string
+    {
+        return openssl_decrypt(base64_decode($ciphertext), static::ALGO_AES_256_ECB, $key, OPENSSL_RAW_DATA, $iv);
+    }
+}

--- a/src/Crypto/AesGcm.php
+++ b/src/Crypto/AesGcm.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace WeChatPay\Crypto;
+
+use function in_array;
+use function openssl_get_cipher_methods;
+use function openssl_encrypt;
+use function base64_encode;
+use function base64_decode;
+use function substr;
+use function strlen;
+use function openssl_decrypt;
+
+use const OPENSSL_RAW_DATA;
+
+use RuntimeException;
+
+/**
+ * Aes encrypt/decrypt using `aes-256-gcm` algorithm with additional authenticated data(`aad`).
+ */
+class AesGcm implements AesInterface
+{
+    /**
+     * Detect the ext-openssl whether or nor including the `aes-256-gcm` algorithm
+     *
+     * @return void
+     * @throws RuntimeException
+     */
+    private static function preCondition(): void
+    {
+        if (!in_array(static::ALGO_AES_256_GCM, openssl_get_cipher_methods())) {
+            throw new RuntimeException('It looks like the ext-openssl extension missing the `aes-256-gcm` cipher method.');
+        }
+    }
+
+    /**
+     * Encrypts given data with given key, iv and aad, returns a base64 encoded string.
+     *
+     * @param string $plaintext - Text to encode.
+     * @param string $key - The secret key, 32 bytes string.
+     * @param string $iv - The initialization vector, 16 bytes string.
+     * @param string $aad - The additional authenticated data, maybe empty string.
+     *
+     * @return string - The base64-encoded ciphertext.
+     */
+    public static function encrypt(string $plaintext, string $key, string $iv = '', string $aad = ''): string
+    {
+        static::preCondition();
+
+        $ciphertext = openssl_encrypt($plaintext, static::ALGO_AES_256_GCM, $key, OPENSSL_RAW_DATA, $iv, $tag, $aad, static::BLOCK_SIZE);
+
+        return base64_encode($ciphertext . $tag);
+    }
+
+    /**
+     * Takes a base64 encoded string and decrypts it using a given key, iv and aad.
+     *
+     * @param string $ciphertext - The base64-encoded ciphertext.
+     * @param string $key - The secret key, 32 bytes string.
+     * @param string $iv - The initialization vector, 16 bytes string.
+     * @param string $aad - The additional authenticated data, maybe empty string.
+     *
+     * @return string - The utf-8 plaintext.
+     */
+    public static function decrypt(string $ciphertext, string $key, string $iv = '', string $aad = ''): string
+    {
+        static::preCondition();
+
+        $ciphertext = base64_decode($ciphertext);
+        $authTag = substr($ciphertext, -static::BLOCK_SIZE);
+        $tagLength = strlen($authTag);
+
+        /* Manually checking the length of the tag, because the `openssl_decrypt` was mentioned there, it's the caller's responsibility. */
+        if ($tagLength > static::BLOCK_SIZE || ($tagLength < 12 && $tagLength !== 8 && $tagLength !== 4)) {
+            throw new RuntimeException('The inputs `$ciphertext` incomplete, the bytes length must be one of 16, 15, 14, 13, 12, 8 or 4.');
+        }
+
+        return openssl_decrypt(substr($ciphertext, 0, -static::BLOCK_SIZE), static::ALGO_AES_256_GCM, $key, OPENSSL_RAW_DATA, $iv, $authTag, $aad);
+    }
+}

--- a/src/Crypto/AesInterface.php
+++ b/src/Crypto/AesInterface.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace WeChatPay\Crypto;
+
+/**
+ * Advanced Encryption Standard Interface
+ */
+interface AesInterface
+{
+    /**
+     * Bytes Length of the AES block
+     */
+    const BLOCK_SIZE = 16;
+
+    /**
+     * Bytes length of the AES secret key.
+     */
+    const KEY_LENGTH_BYTE = 32;
+
+    /**
+     * Bytes Length of the authentication tag in AEAD cipher mode
+     * @deprecated
+     */
+    const AUTH_TAG_LENGTH_BYTE = 16;
+
+    /**
+     * The `aes-256-gcm` algorithm string
+     */
+    const ALGO_AES_256_GCM = 'aes-256-gcm';
+
+    /**
+     * The `aes-256-ecb` algorithm string
+     */
+    const ALGO_AES_256_ECB = 'aes-256-ecb';
+
+    /**
+     * Encrypts given data with given key and iv, returns a base64 encoded string.
+     *
+     * @param string $plaintext - Text to encode.
+     * @param string $key - The secret key, 32 bytes string.
+     * @param string $iv - The initialization vector, 16 bytes string.
+     *
+     * @return string - The base64-encoded ciphertext.
+     */
+    public static function encrypt(string $plaintext, string $key, string $iv = ''): string;
+
+    /**
+     * Takes a base64 encoded string and decrypts it using a given key and iv.
+     *
+     * @param string $ciphertext - The base64-encoded ciphertext.
+     * @param string $key - The secret key, 32 bytes string.
+     * @param string $iv - The initialization vector, 16 bytes string.
+     *
+     * @return string - The utf-8 plaintext.
+     */
+    public static function decrypt(string $ciphertext, string $key, string $iv = ''): string;
+}

--- a/src/Crypto/Hash.php
+++ b/src/Crypto/Hash.php
@@ -39,7 +39,7 @@ class Hash
      */
     public static function md5(string $thing, string $key = '', $agency = false): string
     {
-        $ctx = hash_init(static::ALGO_MD5);
+        $ctx = hash_init(ALGO_MD5);
 
         hash_update($ctx, $thing) && $key && hash_update($ctx, $agency ? '&secret=' : '&key=') && hash_update($ctx, $key);
 

--- a/src/Crypto/Hash.php
+++ b/src/Crypto/Hash.php
@@ -31,8 +31,8 @@ class Hash
      * when the `key` is Falsey, this method works as normal `MD5`.
      *
      * @param string $thing - The input string.
-     * @param string [$key = ''] - The secret key string.
-     * @param boolean|int|string [$agency = false] - The secret **key** is from wework, placed with `true` or better of the `AgentId` value.
+     * @param string $key - The secret key string.
+     * @param boolean|int|string $agency - The secret **key** is from wework, placed with `true` or better of the `AgentId` value.
      *                                               [spec]{@link https://work.weixin.qq.com/api/doc/90000/90135/90281}
      *
      * @return string - The data signature
@@ -51,7 +51,7 @@ class Hash
      *
      * @param string $thing - The input string.
      * @param string $key - The secret key string.
-     * @param string [$algorithm = sha256] - The algorithm string, default is `sha256`.
+     * @param string $algorithm - The algorithm string, default is `sha256`.
      *
      * @return string - The data signature
      */

--- a/src/Crypto/Hash.php
+++ b/src/Crypto/Hash.php
@@ -12,7 +12,7 @@ use const HASH_HMAC;
 
 const ALGO_MD5 = 'MD5';
 const ALGO_HMAC_SHA256 = 'HMAC-SHA256';
-const WCP_SUPPORT_HASHES = [ALGO_HMAC_SHA256 => 'hmac', ALGO_MD5 => 'md5'];
+const ALGO_DICTONARIES = [ALGO_HMAC_SHA256 => 'hmac', ALGO_MD5 => 'md5'];
 
 /**
  * Crypto hash functions utils.
@@ -32,8 +32,9 @@ class Hash
      *
      * @param string $thing - The input string.
      * @param string $key - The secret key string.
-     * @param boolean|int|string $agency - The secret **key** is from wework, placed with `true` or better of the `AgentId` value.
-     *                                               [spec]{@link https://work.weixin.qq.com/api/doc/90000/90135/90281}
+     * @param boolean|int|string $agency - The secret **key** is from work.weixin.qq.com, default is `false`,
+     *                                     placed with `true` or better of the `AgentId` value.
+     *                                     [spec]{@link https://work.weixin.qq.com/api/doc/90000/90135/90281}
      *
      * @return string - The data signature
      */
@@ -75,6 +76,6 @@ class Hash
      */
     public static function sign(string $type, string $data, string $key): ?string
     {
-        return array_key_exists($type, WCP_SUPPORT_HASHES) ? strtoupper(static::{WCP_SUPPORT_HASHES[$type]}($data, $key)) : null;
+        return array_key_exists($type, ALGO_DICTONARIES) ? strtoupper(static::{ALGO_DICTONARIES[$type]}($data, $key)) : null;
     }
 }

--- a/src/Crypto/Hash.php
+++ b/src/Crypto/Hash.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace WeChatPay\Crypto;
+
+use function hash_init;
+use function hash_update;
+use function hash_final;
+use function array_key_exists;
+use function strtoupper;
+
+use const HASH_HMAC;
+
+const ALGO_MD5 = 'MD5';
+const ALGO_HMAC_SHA256 = 'HMAC-SHA256';
+const WCP_SUPPORT_HASHES = [ALGO_HMAC_SHA256 => 'hmac', ALGO_MD5 => 'md5'];
+
+/**
+ * Crypto hash functions utils.
+ * [Specification]{@link https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=4_3}
+ */
+class Hash
+{
+    /** @var string - hashing `MD5` algorithm */
+    const ALGO_MD5 = ALGO_MD5;
+
+    /** @var string - hashing `HMAC-SHA256` algorithm */
+    const ALGO_HMAC_SHA256 = ALGO_HMAC_SHA256;
+
+    /**
+     * Calculate the input string with an optional secret `key` in MD5,
+     * when the `key` is Falsey, this method works as normal `MD5`.
+     *
+     * @param string $thing - The input string.
+     * @param string [$key = ''] - The secret key string.
+     * @param boolean|int|string [$agency = false] - The secret **key** is from wework, placed with `true` or better of the `AgentId` value.
+     *                                               [spec]{@link https://work.weixin.qq.com/api/doc/90000/90135/90281}
+     *
+     * @return string - The data signature
+     */
+    public static function md5(string $thing, string $key = '', $agency = false): string
+    {
+        $ctx = hash_init(static::ALGO_MD5);
+
+        hash_update($ctx, $thing) && $key && hash_update($ctx, $agency ? '&secret=' : '&key=') && hash_update($ctx, $key);
+
+        return hash_final($ctx);
+    }
+
+    /**
+     * Calculate the input string with a secret `key` as of `algorithm` string which is one of the 'sha256', 'sha512' etc.
+     *
+     * @param string $thing - The input string.
+     * @param string $key - The secret key string.
+     * @param string [$algorithm = sha256] - The algorithm string, default is `sha256`.
+     *
+     * @return string - The data signature
+     */
+    public static function hmac(string $thing, string $key, string $algorithm = 'sha256'): string
+    {
+        $ctx = hash_init($algorithm, HASH_HMAC, $key);
+
+        hash_update($ctx, $thing) && hash_update($ctx, '&key=') && hash_update($ctx, $key);
+
+        return hash_final($ctx);
+    }
+
+    /**
+     * Utils of the data signature calculation.
+     *
+     * @param string $type - The sign type, one of the `MD5` or `HMAC-SHA256`.
+     * @param string $data - The input data.
+     * @param string $key - The secret key string.
+     *
+     * @return ?string - The data signature in UPPERCASE.
+     */
+    public static function sign(string $type, string $data, string $key): ?string
+    {
+        return array_key_exists($type, WCP_SUPPORT_HASHES) ? strtoupper(static::{WCP_SUPPORT_HASHES[$type]}($data, $key)) : null;
+    }
+}

--- a/src/Crypto/Rsa.php
+++ b/src/Crypto/Rsa.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace WeChatPay\Crypto;
+
+use function in_array;
+use function openssl_get_md_methods;
+use function openssl_public_encrypt;
+use function base64_encode;
+use function openssl_verify;
+use function base64_decode;
+use function openssl_sign;
+use function openssl_private_decrypt;
+
+use const OPENSSL_PKCS1_OAEP_PADDING;
+
+use RuntimeException;
+use UnexpectedValueException;
+
+const sha256WithRSAEncryption = 'sha256WithRSAEncryption';
+
+/**
+ * Provides some methods for the RSA `sha256WithRSAEncryption` with `OPENSSL_PKCS1_OAEP_PADDING`.
+ */
+class Rsa
+{
+    /**
+     * Detect the ext-openssl whether or nor including the `sha256WithRSAEncryption` cipher method
+     *
+     * @return void
+     * @throws RuntimeException
+     */
+    private static function preCondition(): void
+    {
+        if (!in_array(sha256WithRSAEncryption, openssl_get_md_methods(true))) {
+            throw new RuntimeException('It looks like the ext-openssl extension missing the `sha256WithRSAEncryption` digest method.');
+        }
+    }
+
+    /**
+     * Encrypts text with `OPENSSL_PKCS1_OAEP_PADDING`.
+     *
+     * @param string $plaintext - Cleartext to encode.
+     * @param OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string $publicKey - A PEM encoded public key.
+     *
+     * @return string - The base64-encoded ciphertext.
+     * @throws UnexpectedValueException
+     */
+    public static function encrypt(string $plaintext, $publicKey): string
+    {
+        if (!openssl_public_encrypt($plaintext, $encrypted, $publicKey, OPENSSL_PKCS1_OAEP_PADDING)) {
+            throw new UnexpectedValueException('Encrypting the input $plaintext failed, please checking your $publicKey whether or nor correct.');
+        }
+
+        return base64_encode($encrypted);
+    }
+
+    /**
+     * Verifying the `message` with given `signature` string that uses `sha256WithRSAEncryption`.
+     *
+     * @param string $message - Content will be `openssl_verify`.
+     * @param string $signature - The base64-encoded ciphertext.
+     * @param OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string $publicKey - A PEM encoded public key.
+     *
+     * @return boolean - True is passed, false is failed.
+     * @throws UnexpectedValueException
+     */
+    public static function verify(string $message, string $signature, $publicKey): bool
+    {
+        static::preCondition();
+
+        if (($result = openssl_verify($message, base64_decode($signature), $publicKey, sha256WithRSAEncryption)) === false) {
+            throw new UnexpectedValueException('Verified the input $message failed, please checking your $publicKey whether or nor correct.');
+        }
+
+        return $result === 1;
+    }
+
+    /**
+     * Creates and returns a `base64_encode` string that uses `sha256WithRSAEncryption`.
+     *
+     * @param string $message - Content will be `openssl_sign`.
+     * @param OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string $privateKey - A PEM encoded private key.
+     *
+     * @return string - The base64-encoded signature.
+     * @throws UnexpectedValueException
+     */
+    public static function sign(string $message, $privateKey): string
+    {
+        static::preCondition();
+
+        if (!openssl_sign($message, $signature, $privateKey, sha256WithRSAEncryption)) {
+            throw new UnexpectedValueException('Signing the input $message failed, please checking your $privateKey whether or nor correct.');
+        }
+
+        return base64_encode($signature);
+    }
+
+    /**
+     * Decrypts base64 encoded string with `privateKey` with `OPENSSL_PKCS1_OAEP_PADDING`.
+     *
+     * @param string $ciphertext - Was previously encrypted string using the corresponding public key.
+     * @param OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string $privateKey - A PEM encoded private key.
+     *
+     * @return string - The utf-8 plaintext.
+     * @throws UnexpectedValueException
+     */
+    public static function decrypt(string $ciphertext, $privateKey): string
+    {
+        if (!openssl_private_decrypt(base64_decode($ciphertext), $decrypted, $privateKey, OPENSSL_PKCS1_OAEP_PADDING)) {
+            throw new UnexpectedValueException('Decrypting the input $ciphertext failed, please checking your $privateKey whether or nor correct.');
+        }
+
+        return $decrypted;
+    }
+}

--- a/src/Crypto/Rsa.php
+++ b/src/Crypto/Rsa.php
@@ -40,7 +40,7 @@ class Rsa
      * Encrypts text with `OPENSSL_PKCS1_OAEP_PADDING`.
      *
      * @param string $plaintext - Cleartext to encode.
-     * @param OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string $publicKey - A PEM encoded public key.
+     * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|resource|array|string $publicKey - A PEM encoded public key.
      *
      * @return string - The base64-encoded ciphertext.
      * @throws UnexpectedValueException
@@ -59,7 +59,7 @@ class Rsa
      *
      * @param string $message - Content will be `openssl_verify`.
      * @param string $signature - The base64-encoded ciphertext.
-     * @param OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string $publicKey - A PEM encoded public key.
+     * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|resource|array|string $publicKey - A PEM encoded public key.
      *
      * @return boolean - True is passed, false is failed.
      * @throws UnexpectedValueException
@@ -79,7 +79,7 @@ class Rsa
      * Creates and returns a `base64_encode` string that uses `sha256WithRSAEncryption`.
      *
      * @param string $message - Content will be `openssl_sign`.
-     * @param OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string $privateKey - A PEM encoded private key.
+     * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|resource|array|string $privateKey - A PEM encoded private key.
      *
      * @return string - The base64-encoded signature.
      * @throws UnexpectedValueException
@@ -99,7 +99,7 @@ class Rsa
      * Decrypts base64 encoded string with `privateKey` with `OPENSSL_PKCS1_OAEP_PADDING`.
      *
      * @param string $ciphertext - Was previously encrypted string using the corresponding public key.
-     * @param OpenSSLAsymmetricKey|OpenSSLCertificate|resource|array|string $privateKey - A PEM encoded private key.
+     * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|resource|array|string $privateKey - A PEM encoded private key.
      *
      * @return string - The utf-8 plaintext.
      * @throws UnexpectedValueException

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -25,7 +25,7 @@ class Formatter
     /**
      * Generate a random ASCII string aka `nonce`, similar as `random_bytes`.
      *
-     * @param int [$size = 32] - Nonce string length, default is 32.
+     * @param int $size - Nonce string length, default is 32.
      *
      * @return string - base62 random string.
      */
@@ -47,10 +47,10 @@ class Formatter
     /**
      * Formatting for the heading `Authorization` value.
      *
-     * @param string|int $mchid - The merchant ID.
+     * @param string $mchid - The merchant ID.
      * @param string $nonce - The Nonce string.
      * @param string $signature - The base64-encoded `Rsa::sign` ciphertext.
-     * @param string|int $timestamp - The `Unix` timestamp.
+     * @param string $timestamp - The `Unix` timestamp.
      * @param string $serial - The serial number of the merchant public certification.
      *
      * @return string - The APIv3 Authorization `header` value
@@ -68,7 +68,7 @@ class Formatter
      *
      * @param string $method - The HTTP verb, must be the uppercase sting.
      * @param string $uri - Combined string with `URL::pathname` and `URL::search`.
-     * @param string|int $timestamp - The `Unix` timestamp, should be the one used in `authorization`.
+     * @param string $timestamp - The `Unix` timestamp, should be the one used in `authorization`.
      * @param string $nonce - The `Nonce` string, should be the one used in `authorization`.
      * @param string $body - The playload string, HTTP `GET` should be an empty string.
      *
@@ -82,7 +82,7 @@ class Formatter
     /**
      * Formatting this `HTTP::response` for `Rsa::verify` input.
      *
-     * @param string|int $timestamp - The `Unix` timestamp, should be the one from `response::headers[Wechatpay-Timestamp]`.
+     * @param string $timestamp - The `Unix` timestamp, should be the one from `response::headers[Wechatpay-Timestamp]`.
      * @param string $nonce - The `Nonce` string, should be the one from `response::headers[Wechatpay-Nonce]`.
      * @param string $body - The response payload string, HTTP status(`201`, `204`) should be an empty string.
      *
@@ -108,11 +108,11 @@ class Formatter
     /**
      * Sort an array by key with `SORT_FLAG_CASE | SORT_NATURAL` flag.
      *
-     * @param array thing - The input array.
+     * @param array $thing - The input array reference.
      *
      * @return array - The sorted array.
      */
-    public static function ksort(array $thing = []): array
+    public static function ksort(array &$thing = []): array
     {
         ksort($thing, SORT_FLAG_CASE | SORT_NATURAL);
 

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace WeChatPay;
+
+use function preg_replace_callback;
+use function rand;
+use function str_repeat;
+use function time;
+use function sprintf;
+use function implode;
+use function array_merge;
+use function ksort;
+use function is_null;
+
+use const SORT_FLAG_CASE;
+use const SORT_NATURAL;
+
+const BASE62_CHARS = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+/**
+ * Provides easy used methods using in this project.
+ */
+class Formatter
+{
+    /**
+     * Generate a random ASCII string aka `nonce`, similar as `random_bytes`.
+     *
+     * @param int [$size = 32] - Nonce string length, default is 32.
+     *
+     * @return string - base62 random string.
+     */
+    public static function nonce(int $size = 32): string
+    {
+        return preg_replace_callback('#0#', static function() { return BASE62_CHARS[rand(0, 61)]; }, str_repeat('0', $size));
+    }
+
+    /**
+     * Retrieve the current `Unix` timestamp.
+     *
+     * @return int - Epoch timestamp.
+     */
+    public static function timestamp(): int
+    {
+        return time();
+    }
+
+    /**
+     * Formatting for the heading `Authorization` value.
+     *
+     * @param string|int $mchid - The merchant ID.
+     * @param string $nonce - The Nonce string.
+     * @param string $signature - The base64-encoded `Rsa::sign` ciphertext.
+     * @param string|int $timestamp - The `Unix` timestamp.
+     * @param string $serial - The serial number of the merchant public certification.
+     *
+     * @return string - The APIv3 Authorization `header` value
+     */
+    public static function authorization(string $mchid, string $nonce, string $signature, string $timestamp, string $serial): string
+    {
+        return sprintf(
+            'WECHATPAY2-SHA256-RSA2048 mchid="%s",nonce_str="%s",signature="%s",timestamp="%s",serial_no="%s"',
+            $mchid, $nonce, $signature, $timestamp, $serial
+        );
+    }
+
+    /**
+     * Formatting this `HTTP::request` for `Rsa::sign` input.
+     *
+     * @param string $method - The HTTP verb, must be the uppercase sting.
+     * @param string $uri - Combined string with `URL::pathname` and `URL::search`.
+     * @param string|int $timestamp - The `Unix` timestamp, should be the one used in `authorization`.
+     * @param string $nonce - The `Nonce` string, should be the one used in `authorization`.
+     * @param string $body - The playload string, HTTP `GET` should be an empty string.
+     *
+     * @return string - The content for `Rsa::sign`
+     */
+    public static function request(string $method, string $uri, string $timestamp, string $nonce, string $body = ''): string
+    {
+        return static::joinedByLineFeed($method, $uri, $timestamp, $nonce, $body);
+    }
+
+    /**
+     * Formatting this `HTTP::response` for `Rsa::verify` input.
+     *
+     * @param string|int $timestamp - The `Unix` timestamp, should be the one from `response::headers[Wechatpay-Timestamp]`.
+     * @param string $nonce - The `Nonce` string, should be the one from `response::headers[Wechatpay-Nonce]`.
+     * @param string $body - The response payload string, HTTP status(`201`, `204`) should be an empty string.
+     *
+     * @return string - The content for `Rsa::verify`
+     */
+    public static function response(string $timestamp, string $nonce, string $body = ''): string
+    {
+        return static::joinedByLineFeed($timestamp, $nonce, $body);
+    }
+
+    /**
+     * Joined this inputs by for `Line Feed`(LF) char.
+     *
+     * @param string[] ...$pieces - The string(s) joined by line feed.
+     *
+     * @return string - The joined string.
+     */
+    public static function joinedByLineFeed(...$pieces): string
+    {
+        return implode("\n", array_merge($pieces, ['']));
+    }
+
+    /**
+     * Sort an array by key with `SORT_FLAG_CASE | SORT_NATURAL` flag.
+     *
+     * @param array thing - The input array.
+     *
+     * @return array - The sorted array.
+     */
+    public static function ksort(array $thing = []): array
+    {
+        ksort($thing, SORT_FLAG_CASE | SORT_NATURAL);
+
+        return $thing;
+    }
+
+    /**
+     * Like `queryString` does but without the `sign` and `empty value` entities.
+     *
+     * @param array $thing - The input array.
+     *
+     * @return string - The `key=value` pair string whose joined by `&` char.
+     */
+    public static function queryStringLike(array $thing = []): string
+    {
+        $data = [];
+
+        foreach ($thing as $key => $value) {
+            if ($key === 'sign' || is_null($value) || $value === '') {
+                continue;
+            }
+            $data[] = implode('=', [$key, $value]);
+        }
+
+        return implode('&', $data);
+    }
+}

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -108,11 +108,11 @@ class Formatter
     /**
      * Sort an array by key with `SORT_FLAG_CASE | SORT_NATURAL` flag.
      *
-     * @param array $thing - The input array reference.
+     * @param array $thing - The input array.
      *
      * @return array - The sorted array.
      */
-    public static function ksort(array &$thing = []): array
+    public static function ksort(array $thing = []): array
     {
         ksort($thing, SORT_FLAG_CASE | SORT_NATURAL);
 

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -108,9 +108,9 @@ class Formatter
     /**
      * Sort an array by key with `SORT_FLAG_CASE | SORT_NATURAL` flag.
      *
-     * @param array $thing - The input array.
+     * @param array<string, string|int> $thing - The input array.
      *
-     * @return array - The sorted array.
+     * @return array<string, string|int> - The sorted array.
      */
     public static function ksort(array $thing = []): array
     {
@@ -122,7 +122,7 @@ class Formatter
     /**
      * Like `queryString` does but without the `sign` and `empty value` entities.
      *
-     * @param array $thing - The input array.
+     * @param array<string, string|int|null> $thing - The input array.
      *
      * @return string - The `key=value` pair string whose joined by `&` char.
      */

--- a/src/Transformer.php
+++ b/src/Transformer.php
@@ -32,7 +32,7 @@ class Transformer
      *                                                    | `LIBXML_NOCDATA`
      *                                                    | `LIBXML_NOBLANKS`
      *
-     * @param string [$xml = '<xml/>'] - The xml string
+     * @param string $xml - The xml string, default is `<xml/>` string
      *
      * @return array - The array
      */
@@ -65,7 +65,7 @@ class Transformer
     /**
      * Cast the value $thing, specially doing the `array`, `object`, `SimpleXMLElement` to `array`
      *
-     * @param string|array|object|SimpleXMLElement &$thing - The value thing
+     * @param string|array|object|SimpleXMLElement $thing - The value thing reference
      *
      * @return void
      */
@@ -96,10 +96,10 @@ class Transformer
      * Transform the given $data array as of an XML string.
      *
      * @param array $data - The data array
-     * @param boolean [$headless = true] - The headless flag, default True means without the `<?xml version="1.0" encoding="UTF-8" ?>` doctype
-     * @param boolean [indent = false] - Toggle indentation on/off, default is off
-     * @param string [$root = 'xml'] - The root node label
-     * @param string [$item = 'item'] - The nest array identify text
+     * @param boolean $headless - The headless flag, default `true` means without the `<?xml version="1.0" encoding="UTF-8" ?>` doctype
+     * @param boolean $indent - Toggle indentation on/off, default is `false` off
+     * @param string $root - The root node label, default is `xml` string
+     * @param string $item - The nest array identify text, default is `item` string
      *
      * @return string - The xml string
      */
@@ -122,7 +122,7 @@ class Transformer
     /**
      * Walk the given data array by the `XMLWriter` instance.
      *
-     * @param XMLWritter &$writer - The `XMLWritter` instance
+     * @param \XMLWritter $writer - The `XMLWritter` instance reference
      * @param array $data - The data array
      * @param string $item - The nest array identify tag text
      *
@@ -148,7 +148,7 @@ class Transformer
      * The content text includes the characters `<`, `>`, `&` and `"` are written as CDATA references.
      * All others including `'` are written literally.
      *
-     * @param XMLWritter &$writer - The `XMLWritter` instance
+     * @param \XMLWritter $writer - The `XMLWritter` instance reference
      * @param string|null $thing - The content text
      *
      * @return void
@@ -176,7 +176,7 @@ class Transformer
     /**
      * Checks if a value contains any characters which would require CDATA wrapping.
      *
-     * Notes here: the `XMLWriter` shall been wrapped the '"' string as '&quot;' symbol string,
+     * Notes here: the `XMLWriter` shall been wrapped the `"` string as `&quot;` symbol string,
      *             it's strictly following the `XMLWriter` specification here.
      *
      * @see Symfony\Component\Serializer\Encoder\XmlEncoder::needsCdataWrapping

--- a/src/Transformer.php
+++ b/src/Transformer.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace WeChatPay;
+
+use const LIBXML_VERSION;
+use const LIBXML_NONET;
+use const LIBXML_COMPACT;
+use const LIBXML_NOCDATA;
+use const LIBXML_NOBLANKS;
+
+use function array_walk;
+use function is_array;
+use function is_object;
+use function preg_replace;
+use function strpos;
+use function preg_match;
+
+use SimpleXMLElement;
+use Traversable;
+use XMLWriter;
+
+/**
+ * Transform the `XML` to `Array` or `Array` to `XML`.
+ */
+class Transformer
+{
+    /**
+     * Convert the $xml string to array.
+     *
+     * Always issue the `additional Libxml parameters` asof `LIBXML_NONET`
+     *                                                    | `LIBXML_COMPACT`
+     *                                                    | `LIBXML_NOCDATA`
+     *                                                    | `LIBXML_NOBLANKS`
+     *
+     * @param string [$xml = '<xml/>'] - The xml string
+     *
+     * @return array - The array
+     */
+    public static function toArray(string $xml = '<xml/>'): array
+    {
+        LIBXML_VERSION < 20900 && $previous = libxml_disable_entity_loader(true);
+
+        $el = simplexml_load_string(static::sanitize($xml), SimpleXMLElement::class, LIBXML_NONET | LIBXML_COMPACT | LIBXML_NOCDATA | LIBXML_NOBLANKS);
+
+        LIBXML_VERSION < 20900 && libxml_disable_entity_loader($previous);
+
+        return static::cast($el);
+    }
+
+    /**
+     * Recursive cast the $thing as array data structure.
+     *
+     * @param array|object|SimpleXMLElement $thing - The thing
+     *
+     * @return array - The array
+     */
+    protected static function cast($thing): array
+    {
+        $data = (array) $thing;
+        array_walk($data, ['static', 'value']);
+
+        return $data;
+    }
+
+    /**
+     * Cast the value $thing, specially doing the `array`, `object`, `SimpleXMLElement` to `array`
+     *
+     * @param string|array|object|SimpleXMLElement &$thing - The value thing
+     *
+     * @return void
+     */
+    protected static function value(&$thing): void
+    {
+        is_array($thing) && $thing = static::cast($thing);
+        if (is_object($thing) && $thing instanceof SimpleXMLElement) {
+            $thing = $thing->count() ? static::cast($thing) : (string) $thing;
+        }
+    }
+
+    /**
+     * Trim invalid characters from the $xml string
+     *
+     * @see https://github.com/w7corp/easywechat/pull/1419
+     * @license https://github.com/w7corp/easywechat/blob/4.x/LICENSE
+     *
+     * @param string $xml
+     *
+     * @return string
+     */
+    public static function sanitize(string $xml): string
+    {
+        return preg_replace('#[^\x{9}\x{A}\x{D}\x{20}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]+#u', '', $xml);
+    }
+
+    /**
+     * Transform the given $data array as of an XML string.
+     *
+     * @param array $data - The data array
+     * @param boolean [$headless = true] - The headless flag, default True means without the `<?xml version="1.0" encoding="UTF-8" ?>` doctype
+     * @param boolean [indent = false] - Toggle indentation on/off, default is off
+     * @param string [$root = 'xml'] - The root node label
+     * @param string [$item = 'item'] - The nest array identify text
+     *
+     * @return string - The xml string
+     */
+    public static function toXml(array $data, bool $headless = true, bool $indent = false, string $root = 'xml', string $item = 'item'): string
+    {
+        $writer = new XMLWriter();
+        $writer->openMemory();
+        $writer->setIndent($indent);
+        $headless || $writer->startDocument('1.0', 'utf-8');
+        $writer->startElement($root);
+        static::walk($writer, $data, $item);
+        $writer->endElement();
+        $headless || $writer->endDocument();
+        $xml = $writer->outputMemory();
+        $writer = null;
+
+        return $xml;
+    }
+
+    /**
+     * Walk the given data array by the `XMLWriter` instance.
+     *
+     * @param XMLWritter &$writer - The `XMLWritter` instance
+     * @param array $data - The data array
+     * @param string $item - The nest array identify tag text
+     *
+     * @return void
+     */
+    protected static function walk(XMLWriter &$writer, array $data, string $item): void
+    {
+        foreach ($data as $key => $value) {
+            $tag = static::isElementNameValid($key) ? $key : $item;
+            $writer->startElement($tag);
+            if (is_array($value) || (is_object($value) && $value instanceof Traversable)) {
+                static::walk($writer, (array) $value, $item);
+            } else {
+                static::content($writer, $value);
+            }
+            $writer->endElement();
+        }
+    }
+
+    /**
+     * Write content text.
+     *
+     * The content text includes the characters `<`, `>`, `&` and `"` are written as CDATA references.
+     * All others including `'` are written literally.
+     *
+     * @param XMLWritter &$writer - The `XMLWritter` instance
+     * @param string|null $thing - The content text
+     *
+     * @return void
+     */
+    protected static function content(XMLWriter &$writer, ?string $thing = null): void
+    {
+        static::needsCdataWrapping($thing) && $writer->writeCdata($thing) || $writer->text($thing);
+    }
+
+    /**
+     * Checks the name is a valid xml element name.
+     *
+     * @see Symfony\Component\Serializer\Encoder\XmlEncoder::isElementNameValid
+     * @license https://github.com/symfony/serializer/blob/5.3/LICENSE
+     *
+     * @param string|null $name - The name
+     *
+     * @return boolean - True means valid
+     */
+    protected static function isElementNameValid(?string $name = null): bool
+    {
+        return $name && false === strpos($name, ' ') && preg_match('#^[\pL_][\pL0-9._:-]*$#ui', $name);
+    }
+
+    /**
+     * Checks if a value contains any characters which would require CDATA wrapping.
+     *
+     * Notes here: the `XMLWriter` shall been wrapped the '"' string as '&quot;' symbol string,
+     *             it's strictly following the `XMLWriter` specification here.
+     *
+     * @see Symfony\Component\Serializer\Encoder\XmlEncoder::needsCdataWrapping
+     * @license https://github.com/symfony/serializer/blob/5.3/LICENSE
+     *
+     * @param string|null $value - The value
+     *
+     * @return boolean - True means need
+     */
+    protected static function needsCdataWrapping(?string $value = null): bool
+    {
+        return 0 < preg_match('#[>&"<]#', $value);
+    }
+}

--- a/src/Util/MediaUtil.php
+++ b/src/Util/MediaUtil.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace WeChatPay\Util;
+
+use function basename;
+
+use GuzzleHttp\Utils as GHU;
+use GuzzleHttp\Psr7\Utils;
+use GuzzleHttp\Psr7\LazyOpenStream;
+use GuzzleHttp\Psr7\MultipartStream;
+use GuzzleHttp\Psr7\FnStream;
+use GuzzleHttp\Psr7\CachingStream;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * Util for Media(image or video) uploading.
+ */
+class MediaUtil
+{
+    /**
+     * local file path
+     *
+     * @var string
+     */
+    private $filepath;
+
+    /**
+     * file content stream to upload
+     * @var string
+     */
+    private $fileStream;
+
+    /**
+     * upload meta json string
+     *
+     * @var string
+     */
+    private $meta;
+
+    /**
+     * upload contents stream
+     *
+     * @var MultipartStream
+     */
+    private $multipart;
+
+
+    /**
+     * multipart stream wrapper
+     *
+     * @var StreamInterface
+     */
+    private $stream;
+
+    /**
+     * Constructor
+     *
+     * @param string $filepath The media file path or file name,
+     *                         should be one of the
+     *                         images(jpg|bmp|png)
+     *                         or
+     *                         video(avi|wmv|mpeg|mp4|mov|mkv|flv|f4v|m4v|rmvb)
+     * @param StreamInterface $fileStream  File content stream, optional
+     */
+    public function __construct(string $filepath, ?StreamInterface $fileStream = null)
+    {
+        $this->filepath = $filepath;
+        $this->fileStream = $fileStream;
+        $this->composeStream();
+    }
+
+    /**
+     * Compose the GuzzleHttp\Psr7\FnStream
+     */
+    private function composeStream(): void
+    {
+        $basename = basename($this->filepath);
+        $stream = $this->fileStream ?? new LazyOpenStream($this->filepath, 'r');
+        if (!$stream->isSeekable()) {
+            $stream = new CachingStream($stream);
+        }
+
+        $json = GHU::jsonEncode([
+            'filename' => $basename,
+            'sha256'   => Utils::hash($stream, 'sha256'),
+        ]);
+        $this->meta = $json;
+
+        $multipart = new MultipartStream([
+            [
+                'name'     => 'meta',
+                'contents' => $json,
+                'headers'  => [
+                    'Content-Type' => 'application/json',
+                ],
+            ],
+            [
+                'name'     => 'file',
+                'filename' => $basename,
+                'contents' => $stream,
+            ],
+        ]);
+        $this->multipart = $multipart;
+
+        $this->stream = FnStream::decorate($multipart, [
+             // for signature
+            '__toString' => function () use ($json) {
+                return $json;
+            },
+             // let the `CURL` to use `CURLOPT_UPLOAD` context
+            'getSize' => function () {
+                return null;
+            },
+        ]);
+    }
+
+    /**
+     * Get the `meta` of the multipart data string
+     */
+    public function getMeta(): string
+    {
+        return $this->meta;
+    }
+
+    /**
+     * Get the `GuzzleHttp\Psr7\FnStream` context
+     */
+    public function getStream(): StreamInterface
+    {
+        return $this->stream;
+    }
+
+    /**
+     * Get the `Content-Type` of the `GuzzleHttp\Psr7\MultipartStream`
+     */
+    public function getContentType(): string
+    {
+        return 'multipart/form-data; boundary=' . $this->multipart->getBoundary();
+    }
+}

--- a/src/Util/PemUtil.php
+++ b/src/Util/PemUtil.php
@@ -19,6 +19,7 @@ class PemUtil
      * Read private key from file
      *
      * @param string $filepath - PEM encoded private key file path
+     * @param null|string $passphrase The optional parameter passphrase must be used if the specified key is encrypted (protected by a passphrase).
      *
      * @return OpenSSLAsymmetricKey|resource|bool - Private key resource identifier on success, or FALSE on error
      */
@@ -43,7 +44,7 @@ class PemUtil
      * Read private key from string
      *
      * @param OpenSSLAsymmetricKey|resource|array|string $content - PEM encoded private key string content
-     * @param ?string $passphrase The optional parameter passphrase must be used if the specified key is encrypted (protected by a passphrase).
+     * @param null|string $passphrase The optional parameter passphrase must be used if the specified key is encrypted (protected by a passphrase).
      *
      * @return OpenSSLAsymmetricKey|resource|bool - Private key resource identifier on success, or FALSE on error
      */
@@ -76,7 +77,7 @@ class PemUtil
     {
         $info = openssl_x509_parse($certificate);
         if (false === $info || !isset($info['serialNumberHex'])) {
-            throw new InvalidArgumentException('证书格式错误');
+            throw new InvalidArgumentException('Read the $certificate failed, please check it whether or nor correct');
         }
 
         return strtoupper($info['serialNumberHex'] ?? '');

--- a/src/Util/PemUtil.php
+++ b/src/Util/PemUtil.php
@@ -21,7 +21,7 @@ class PemUtil
      * @param string $filepath - PEM encoded private key file path
      * @param null|string $passphrase The optional parameter passphrase must be used if the specified key is encrypted (protected by a passphrase).
      *
-     * @return OpenSSLAsymmetricKey|resource|bool - Private key resource identifier on success, or FALSE on error
+     * @return \OpenSSLAsymmetricKey|resource|bool - Private key resource identifier on success, or FALSE on error
      */
     public static function loadPrivateKey(string $filepath, ?string $passphrase = null)
     {
@@ -33,7 +33,7 @@ class PemUtil
      *
      * @param string $filepath - PEM encoded X.509 certificate file path
      *
-     * @return OpenSSLCertificate|resource|bool - X.509 certificate resource identifier on success or FALSE on failure
+     * @return \OpenSSLCertificate|resource|bool - X.509 certificate resource identifier on success or FALSE on failure
      */
     public static function loadCertificate(string $filepath)
     {
@@ -43,10 +43,10 @@ class PemUtil
     /**
      * Read private key from string
      *
-     * @param OpenSSLAsymmetricKey|resource|array|string $content - PEM encoded private key string content
+     * @param \OpenSSLAsymmetricKey|resource|string $content - PEM encoded private key string content
      * @param null|string $passphrase The optional parameter passphrase must be used if the specified key is encrypted (protected by a passphrase).
      *
-     * @return OpenSSLAsymmetricKey|resource|bool - Private key resource identifier on success, or FALSE on error
+     * @return \OpenSSLAsymmetricKey|resource|bool - Private key resource identifier on success, or FALSE on error
      */
     public static function loadPrivateKeyFromString($content, ?string $passphrase = null)
     {
@@ -56,9 +56,9 @@ class PemUtil
     /**
      * Read certificate from string
      *
-     * @param OpenSSLCertificate|resource|string $content - PEM encoded X.509 certificate string content
+     * @param \OpenSSLCertificate|resource|string $content - PEM encoded X.509 certificate string content
      *
-     * @return OpenSSLCertificate|resource|bool - X.509 certificate resource identifier on success or FALSE on failure
+     * @return \OpenSSLCertificate|resource|bool - X.509 certificate resource identifier on success or FALSE on failure
      */
     public static function loadCertificateFromString($content)
     {
@@ -68,7 +68,7 @@ class PemUtil
     /**
      * Parse Serial Number from Certificate
      *
-     * @param OpenSSLCertificate|resource|string $certifcates Certificates string or resource
+     * @param \OpenSSLCertificate|resource|string $certificate Certificates string or resource
      *
      * @return string - The serial number
      * @throws InvalidArgumentException

--- a/src/Util/PemUtil.php
+++ b/src/Util/PemUtil.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace WeChatPay\Util;
+
+use function openssl_get_privatekey;
+use function openssl_x509_read;
+use function openssl_x509_parse;
+use function file_get_contents;
+use function strtoupper;
+
+use InvalidArgumentException;
+
+/**
+ * Util for read private key and certificate.
+ */
+class PemUtil
+{
+    /**
+     * Read private key from file
+     *
+     * @param string $filepath - PEM encoded private key file path
+     *
+     * @return OpenSSLAsymmetricKey|resource|bool - Private key resource identifier on success, or FALSE on error
+     */
+    public static function loadPrivateKey(string $filepath, ?string $passphrase = null)
+    {
+        return openssl_get_privatekey(file_get_contents($filepath), $passphrase);
+    }
+
+    /**
+     * Read certificate from file
+     *
+     * @param string $filepath - PEM encoded X.509 certificate file path
+     *
+     * @return OpenSSLCertificate|resource|bool - X.509 certificate resource identifier on success or FALSE on failure
+     */
+    public static function loadCertificate(string $filepath)
+    {
+        return openssl_x509_read(file_get_contents($filepath));
+    }
+
+    /**
+     * Read private key from string
+     *
+     * @param OpenSSLAsymmetricKey|resource|array|string $content - PEM encoded private key string content
+     * @param ?string $passphrase The optional parameter passphrase must be used if the specified key is encrypted (protected by a passphrase).
+     *
+     * @return OpenSSLAsymmetricKey|resource|bool - Private key resource identifier on success, or FALSE on error
+     */
+    public static function loadPrivateKeyFromString($content, ?string $passphrase = null)
+    {
+        return openssl_get_privatekey($content, $passphrase);
+    }
+
+    /**
+     * Read certificate from string
+     *
+     * @param OpenSSLCertificate|resource|string $content - PEM encoded X.509 certificate string content
+     *
+     * @return OpenSSLCertificate|resource|bool - X.509 certificate resource identifier on success or FALSE on failure
+     */
+    public static function loadCertificateFromString($content)
+    {
+        return openssl_x509_read($content);
+    }
+
+    /**
+     * Parse Serial Number from Certificate
+     *
+     * @param OpenSSLCertificate|resource|string $certifcates Certificates string or resource
+     *
+     * @return string - The serial number
+     * @throws InvalidArgumentException
+     */
+    public static function parseCertificateSerialNo($certificate): string
+    {
+        $info = openssl_x509_parse($certificate);
+        if (false === $info || !isset($info['serialNumberHex'])) {
+            throw new InvalidArgumentException('证书格式错误');
+        }
+
+        return strtoupper($info['serialNumberHex'] ?? '');
+    }
+}


### PR DESCRIPTION
- 完全重构版本，PHP最低版本要求 7.2.5
- 升级`Guzzle`至7.0+
- 改写了加解密功能，修复 wechatpay-apiv3/wechatpay-guzzle-middleware#25
- 同时支持`同步`及`异步`链式调用
- 改写了证书下载器，可以用来参考如何异步编程