### PR TITLE
add `encrypted privateKey` testcases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ keygen:
 	openssl rsa -in ./tests/fixtures/mock.pkcs8.key -out ./tests/fixtures/mock.pkcs1.key
 	openssl rsa -in ./tests/fixtures/mock.pkcs8.key -pubout -out ./tests/fixtures/mock.spki.pem
 	openssl rsa -pubin -in ./tests/fixtures/mock.spki.pem -RSAPublicKey_out -out ./tests/fixtures/mock.pkcs1.pem
-	openssl rand -hex 16 -out ./tests/fixtures/mock.pwd.txt
+	openssl rand -out ./tests/fixtures/mock.pwd.txt -hex 16
 	openssl pkcs8 -in ./tests/fixtures/mock.pkcs8.key -passout file:./tests/fixtures/mock.pwd.txt -topk8 -out ./tests/fixtures/mock.encrypted.pkcs8.key
 
 x509crt:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ keygen:
 	openssl rsa -in ./tests/fixtures/mock.pkcs8.key -out ./tests/fixtures/mock.pkcs1.key
 	openssl rsa -in ./tests/fixtures/mock.pkcs8.key -pubout -out ./tests/fixtures/mock.spki.pem
 	openssl rsa -pubin -in ./tests/fixtures/mock.spki.pem -RSAPublicKey_out -out ./tests/fixtures/mock.pkcs1.pem
+	openssl rand -hex 16 -out ./tests/fixtures/mock.pwd.txt
+	openssl pkcs8 -in ./tests/fixtures/mock.pkcs8.key -passout file:./tests/fixtures/mock.pwd.txt -topk8 -out ./tests/fixtures/mock.encrypted.pkcs8.key
 
 x509crt:
 	fixtures="./tests/fixtures/" && serial=$$(openssl rand -hex 20 | \

--- a/src/Crypto/Rsa.php
+++ b/src/Crypto/Rsa.php
@@ -169,7 +169,7 @@ class Rsa
      * - full `PEM` format privateKey/publicKey(x509 certificate) string.
      * - `\OpenSSLAsymmetricKey` (PHP8) or `resource#pkey` (PHP7).
      * - `\OpenSSLCertificate` (PHP8) or `resource#X509` (PHP7) for publicKey.
-     * - `Array` of `[privateKeyString,passpharse]` for encrypted privateKey.
+     * - `Array` of `[privateKeyString,passphrase]` for encrypted privateKey.
      *
      * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|resource|array{string,string}|string|mixed $thing - The thing.
      * @param string $type - Either `self::KEY_TYPE_PUBLIC` or `self::KEY_TYPE_PRIVATE` string, default is `self::KEY_TYPE_PRIVATE`.
@@ -221,9 +221,9 @@ class Rsa
      *   - `\OpenSSLAsymmetricKey` (PHP8) or `resource#pkey` (PHP7) for publicKey/privateKey.
      *   - `\OpenSSLCertificate` (PHP8) or `resource#X509` (PHP7) for publicKey.
      *
-     * The `\$thing` can be the Array<$privateKey,$passpharse> style for loading privateKey, eg:
-     *   - [`file:///my/path/to/private.pkcs8.key`, 'your_pass_pharse']
-     *   - [`-----BEGIN ENCRYPTED PRIVATE KEY-----...-----END ENCRYPTED PRIVATE KEY-----`, 'your_pass_pharse']
+     * The `\$thing` can be the Array{$privateKey,$passphrase} style for loading privateKey, eg:
+     *   - [`file:///my/path/to/private.pkcs8.key`, 'your_pass_phrase']
+     *   - [`-----BEGIN ENCRYPTED PRIVATE KEY-----...-----END ENCRYPTED PRIVATE KEY-----`, 'your_pass_phrase']
      *
      * @param \OpenSSLAsymmetricKey|\OpenSSLCertificate|resource|array{string,string}|string|mixed $thing - The thing.
      * @param string $type - Either `self::KEY_TYPE_PUBLIC` or `self::KEY_TYPE_PRIVATE` string, default is `self::KEY_TYPE_PRIVATE`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,6 +27,8 @@ openssl rsa -in ./tests/fixtures/mock.pkcs8.key -pubout -out ./tests/fixtures/mo
 writing RSA key
 openssl rsa -pubin -in ./tests/fixtures/mock.spki.pem -RSAPublicKey_out -out ./tests/fixtures/mock.pkcs1.pem
 writing RSA key
+openssl rand -hex 16 -out ./tests/fixtures/mock.pwd.txt
+openssl pkcs8 -in ./tests/fixtures/mock.pkcs8.key -passout file:./tests/fixtures/mock.pwd.txt -topk8 -out ./tests/fixtures/mock.encrypted.pkcs8.key
 fixtures="./tests/fixtures/" && serial=$(openssl rand -hex 20 | awk '{ if (match($0,/^00/)) s="01"substr($0,3,length($0)); else s=$0; print toupper(s) }' | tee ${fixtures}mock.serial.txt) && \
 	MSYS_NO_PATHCONV=1 openssl req -new -sha256 -key ${fixtures}mock.pkcs8.key \
 		-subj "/C=CN/ST=Shanghai/O=WeChatPay Community/CN=WeChatPay Community CI" | \
@@ -40,67 +42,67 @@ Certificate:
     Data:
         Version: 1 (0x0)
         Serial Number:
-            2a:0d:4e:bf:bd:8d:e2:44:d3:ae:97:1a:a3:d7:a1:3a:e7:61:5b:03
+            71:32:d7:2a:03:e9:3c:dd:f3:e2:5b:87:68:c0:3b:bd:1f:37:ee:df
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: C=CN, ST=Shanghai, O=WeChatPay Community, CN=WeChatPay Community CI
         Validity
-            Not Before: Sep  2 11:09:29 2021 GMT
-            Not After : Sep  3 11:09:29 2021 GMT
+            Not Before: Sep  3 07:01:04 2021 GMT
+            Not After : Sep  4 07:01:04 2021 GMT
         Subject: C=CN, ST=Shanghai, O=WeChatPay Community, CN=WeChatPay Community CI
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (2048 bit)
                 Modulus:
-                    00:c9:da:cc:db:92:df:1c:6f:16:9c:44:11:27:dc:
-                    19:d2:93:32:72:92:41:52:5e:f5:c7:49:a2:8a:90:
-                    95:cf:6a:16:6c:89:af:46:35:e3:c6:da:ee:14:76:
-                    07:d8:23:c5:35:ac:39:be:69:ca:b4:3d:4e:cc:d3:
-                    0d:ea:f6:38:cc:8c:8f:1c:38:58:ed:93:3f:06:83:
-                    48:e0:ab:e0:e0:a8:d4:8a:6c:1f:96:34:28:4f:21:
-                    59:a6:95:84:14:c9:e0:74:66:b6:5e:d6:0b:56:93:
-                    a4:6f:02:eb:4d:d2:1c:84:f8:43:1a:87:04:46:eb:
-                    e7:12:81:05:a7:13:a0:11:79:18:82:2c:dd:22:62:
-                    f1:b3:67:70:fb:08:78:33:55:36:b2:6d:2b:01:79:
-                    bf:69:ed:36:69:fc:a8:16:9f:6f:5f:69:53:e2:25:
-                    ff:63:bd:76:be:b5:da:1f:bc:42:8e:ec:4a:6e:f5:
-                    99:24:ba:1d:f2:a1:27:76:54:b8:e6:5d:6b:5d:5f:
-                    65:a9:23:53:f0:1b:4f:3c:8a:0e:84:65:74:85:65:
-                    3e:91:d6:b2:13:1b:b8:91:13:c1:7b:9f:81:71:48:
-                    fb:75:ce:47:6c:38:d9:45:15:2c:b2:8c:12:4e:57:
-                    29:68:f4:ab:d1:88:89:15:ab:93:65:54:33:49:e7:
-                    05:41
+                    00:b8:44:6f:fa:cc:4d:38:99:f9:35:26:23:17:d4:
+                    9c:b5:61:f1:bb:64:6e:4f:b5:7c:04:49:91:56:c6:
+                    63:7a:cd:4e:a0:fe:5b:bf:b2:ba:32:67:c6:c9:65:
+                    ca:80:9a:16:b1:06:0e:4b:f5:92:47:5f:a5:52:b1:
+                    a0:b7:19:65:4d:c9:49:a6:7a:41:f1:af:a5:01:f0:
+                    26:3b:4a:0b:37:3d:5e:7a:03:5f:a3:06:aa:a2:e3:
+                    ad:ad:0d:08:1b:c0:5a:7d:02:16:92:7b:9b:c3:04:
+                    9b:3f:7a:91:8c:7c:2a:72:a4:51:43:55:b0:53:29:
+                    01:0f:54:36:71:db:0e:ca:46:05:3c:14:25:83:9f:
+                    b7:89:6e:42:0e:d9:a9:c0:95:fa:52:89:61:64:02:
+                    c5:ec:9c:c7:01:bb:bf:a1:4d:c1:f2:41:92:38:cb:
+                    52:f4:ff:aa:f0:b8:0c:0e:f0:ac:ec:2f:f8:07:35:
+                    05:21:1d:67:ea:8b:92:70:15:6d:6b:2e:59:65:89:
+                    5b:a0:75:ce:02:cb:d4:db:c2:dd:01:3d:07:d0:51:
+                    bf:0f:03:f1:8a:dd:23:72:92:22:5a:29:f2:04:a7:
+                    85:70:cb:9a:18:85:98:a1:aa:b9:d6:e5:55:01:b1:
+                    47:90:8b:de:68:d8:55:45:6a:17:b3:c3:40:1d:cf:
+                    38:87
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         05:30:8a:25:26:8d:9a:75:06:f1:4d:af:e6:69:71:ec:c5:a8:
-         61:92:71:ab:1f:aa:ca:f6:cc:75:7f:1c:cd:bf:6f:fc:5f:46:
-         5c:72:db:cf:67:79:cc:a8:62:a3:3c:d4:be:2a:e9:58:d6:da:
-         9e:28:a8:7f:b5:d4:62:74:67:c1:9d:4a:5c:38:a7:52:48:04:
-         d4:b8:ce:87:bb:31:fa:f4:b8:9c:24:df:88:48:10:0a:e7:71:
-         e8:17:80:dc:1d:dc:14:36:13:2d:6e:3b:6a:e5:15:f3:f3:f9:
-         13:8e:f2:1e:28:5e:70:1e:04:b4:f5:35:e9:ec:9b:b9:bc:1b:
-         a5:37:86:e3:9d:7f:e7:d0:d7:e7:9b:68:7e:7e:9f:8e:6c:00:
-         63:96:25:8d:d5:c4:a6:67:e4:78:d9:22:67:d3:1c:8d:7e:a9:
-         a6:af:0b:e9:fd:d2:ae:e2:d4:0b:87:dc:38:fe:4d:ca:cf:fa:
-         8a:45:04:56:8d:c6:55:da:b9:1d:33:cb:89:8d:eb:f8:01:12:
-         de:62:05:a1:f4:a1:49:f8:3b:e8:39:bf:eb:2c:9d:0a:c1:3b:
-         f4:a2:62:13:db:2c:b0:67:be:70:e2:69:1d:fd:b0:9c:9f:e0:
-         52:5a:df:d5:a6:1a:82:13:f1:00:da:70:32:b4:43:95:33:1f:
-         f8:8d:63:54
+         24:cd:eb:63:20:92:05:67:3a:eb:04:9b:89:fb:6b:3c:3b:d3:
+         6c:1e:6c:c4:5a:1f:ac:4d:0a:1a:49:2f:35:86:95:d0:95:dd:
+         f2:1c:53:a0:5f:09:eb:18:c0:be:8e:69:6e:0b:21:d8:a5:2b:
+         cf:ea:e6:01:2a:d0:e6:c4:e7:14:77:27:c9:92:89:c6:b5:58:
+         74:e2:02:be:e4:76:32:45:99:0a:d0:93:65:1c:29:2f:48:ad:
+         39:34:b5:af:98:74:d9:51:b5:17:07:9a:44:48:86:83:82:7f:
+         19:ad:da:76:bf:3b:45:f4:38:a8:19:2d:d8:83:ba:f9:67:3e:
+         aa:e7:da:09:ed:c1:c3:bc:dd:48:31:63:3c:42:42:38:02:1a:
+         da:cb:5d:a8:c8:36:01:bb:82:c6:3e:e0:8e:da:78:3f:8f:94:
+         d3:c9:7e:5d:08:95:fe:d5:3e:fa:9a:2c:ca:fb:4a:d9:3a:12:
+         0d:e7:32:5b:d8:cf:bc:af:e2:50:d4:7b:30:fe:c4:92:6c:57:
+         3a:42:91:d7:bd:be:1d:d5:7c:d1:5c:29:7c:f2:8f:2b:3b:81:
+         44:21:f3:84:b2:e1:e0:10:02:83:7e:20:29:f3:5c:92:19:2b:
+         0d:64:59:0a:d7:76:ef:35:5a:66:bc:82:bf:db:5c:9c:c3:51:
+         d4:5e:b7:bb
 vendor/bin/phpunit
-PHPUnit 9.5.8 by Sebastian Bergmann and contributors.
+PHPUnit 9.5.9 by Sebastian Bergmann and contributors.
 
-...............................................................  63 / 480 ( 13%)
-............................................................... 126 / 480 ( 26%)
-............................................................... 189 / 480 ( 39%)
-............................................................... 252 / 480 ( 52%)
-............................................................... 315 / 480 ( 65%)
-............................................................... 378 / 480 ( 78%)
-............................................................... 441 / 480 ( 91%)
-.......................................                         480 / 480 (100%)
+...............................................................  63 / 490 ( 12%)
+............................................................... 126 / 490 ( 25%)
+............................................................... 189 / 490 ( 38%)
+............................................................... 252 / 490 ( 51%)
+............................................................... 315 / 490 ( 64%)
+............................................................... 378 / 490 ( 77%)
+............................................................... 441 / 490 ( 90%)
+.................................................               490 / 490 (100%)
 
-Time: 00:00.590, Memory: 12.00 MB
+Time: 00:00.615, Memory: 12.00 MB
 
-OK (480 tests, 2145 assertions)
+OK (490 tests, 2177 assertions)
 rm -rf ./tests/fixtures/mock.*
 ```
 


### PR DESCRIPTION
增加 `PKCS#8` 格式的`RSA加密私钥`生成及测试用例覆盖。