### PR TITLE
bump to v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # 变更历史
 
+## [1.4.2](../../compare/v1.4.1...v1.4.2) - 2021-11-08
+
+- 优化`Rsa::parse`代码逻辑，去除`is_resource`/`is_object`检测;
+- 调整`Rsa::from[Pkcs8|Pkcs1|Spki]`加载语法糖实现，以`Rsa::from`为统一入口；
+
 ## [1.4.1](../../compare/v1.4.0...v1.4.1) - 2021-11-03
 
 - 新增`phpstan/phpstan:^1.0`支持；
@@ -12,46 +17,34 @@
 
 详细说明可见[1.3至1.4升级指南](UPGRADING.md)
 
-## 1.3.2 - 2021-09-30
-
-[变更细节](../../compare/v1.3.1...v1.3.2)
+## [1.3.2](../../compare/v1.3.1...v1.3.2) - 2021-09-30
 
 - 增加`MediaUtil::setMeta`函数，以支持特殊场景(API)下`meta`数据结构的特殊需求；
 
-## 1.3.1 - 2021-09-22
-
-[变更细节](../../compare/v1.3.0...v1.3.1)
+## [1.3.1](../../compare/v1.3.0...v1.3.1) - 2021-09-22
 
 - 修正`APIv2`上，合单支付产品`xml`入参是`combine_mch_id`引发的不适问题；
 
-## 1.3.0 - 2021-09-18
-
-[变更细节](../../compare/v1.2.2...v1.3.0)
+## [1.3.0](../../compare/v1.2.2...v1.3.0) - 2021-09-18
 
 - 增加IDE提示`OpenAPI\V2`&`OpenAPI\V3`的两个入口，接口描述文件拆分为单独的包发行，生产环境无需安装（没必要），仅面向开发环境；
 - 优化`userAgent`方法，使拼接`User-Agent`字典清晰可读；
 - 优化`README`，增加`V3`通知验签注释说明，增加`v2`链式`otherwise`处理逻辑说明；
 
-## 1.2.2 - 2021-09-09
-
-[变更细节](../../compare/v1.2.1...v1.2.2)
+## [1.2.2](../../compare/v1.2.1...v1.2.2) - 2021-09-09
 
 - 以`at sign`形式，温和提示`APIv2`的`DEP_XML_PROTOCOL_IS_REACHABLE_EOL`，相关[#38](https://github.com/wechatpay-apiv3/wechatpay-php/issues/38)；
 - 优化`Transformer::toArray`函数，对入参`xml`非法时，返回空`array`，并把最后一条错误信息温和地打入`E_USER_NOTICE`通道；
 - 修正`Formatter::ksort`排列键值时兼容问题，使用`字典序(dictionary order)`排序，相关[#41](https://github.com/wechatpay-apiv3/wechatpay-php/issues/41), 感谢 @suiaiyun 报告此问题；
 
-## 1.2.1 - 2021-09-06
-
-[变更细节](../../compare/v1.2.0...v1.2.1)
+## [1.2.1](../../compare/v1.2.0...v1.2.1) - 2021-09-06
 
 - 增加`加密RSA私钥`的测试用例覆盖；
 - 优化文档样例及升级指南，修正错别字；
 - 优化内部`withDefaults`函数，使用变长参数合并初始化参数；
 - 优化`Rsa::encrypt`及`Rsa::decrpt`方法，增加第三可选参数，以支持`OPENSSL_PKCS1_PADDING`填充模式的加解密；
 
-## 1.2.0 - 2021-09-02
-
-[变更细节](../../compare/v1.1.4...v1.2.0)
+## [1.2.0](../../compare/v1.1.4...v1.2.0) - 2021-09-02
 
 - 新增`Rsa::from`统一加载函数，以接替`PemUtil::loadPrivateKey`函数功能；
 - 新增`Rsa::fromPkcs1`, `Rsa::fromPkcs8`, `Rsa::fromSpki`语法糖，以支持从云端加载RSA公/私钥；
@@ -59,34 +52,26 @@
 - 标记 `PemUtil::loadPrivateKey`及`PemUtil::loadPrivateKeyFromString`为`不推荐用法`;
 - 详细变化可见[1.1至1.2升级指南](UPGRADING.md)
 
-## 1.1.4 - 2021-08-26
-
-[变更细节](../../compare/v1.1.3...v1.1.4)
+## [1.1.4](../../compare/v1.1.3...v1.1.4) - 2021-08-26
 
 - 优化`平台证书下载工具`使用说明，增加`composer exec`执行方法说明；
 - 优化了一点点代码结构，使逻辑更清晰了一些；
 
-## 1.1.3 - 2021-08-22
-
-[变更细节](../../compare/v1.1.2...v1.1.3)
+## [1.1.3](../../compare/v1.1.2...v1.1.3) - 2021-08-22
 
 - 优化`README`，增加`回调通知`处理说明及样本代码；
 - 优化测试用例，使用`严格限定名称`方式引用系统内置函数；
 - 优化`Makefile`，在生成模拟证书时，避免产生`0x00`开头的证书序列号；
 - 调整`composer.json`，新增`guzzlehttp/uri-template:^1.0`支持；
 
-## 1.1.2 - 2021-08-19
-
-[变更细节](../../compare/V1.1.1...v1.1.2)
+## [1.1.2](../../compare/V1.1.1...v1.1.2) - 2021-08-19
 
 - 优化`README`，`密钥`、`证书`等相关术语保持一致；
 - 优化`UPGRADING`，增加从`php_sdk_v3.0.10`迁移指南；
 - 优化测试用例，完整覆盖`PHP7.2/7.3/7.4/8.0 + Linux/macOS/Windows`运行时；
 - 调整`composer.json`，去除`test`, `phpstan`命令，面向生产环境可用；
 
-## 1.1.1 - 2021-08-13
-
-[变更细节](../../compare/v1.1.0...V1.1.1)
+## [1.1.1](../../compare/v1.1.0...V1.1.1) - 2021-08-13
 
 - 优化内部中间件始终从`\GuzzleHttp\Psr7\Stream::__toString`取值，并在取值后，判断如果影响了`Stream`指针，则回滚至开始位;
 - 增加`APIv2`上一些特殊用法示例，增加`数据签名`样例；
@@ -94,61 +79,45 @@
 - 修正`APIv2`上，转账至用户零钱接口，`xml`入参是`mchid`引发的不适问题；
 - 增加`APIv2`上转账至用户零钱接口测试用例，样例说明如何进行异常捕获；
 
-## 1.1.0 - 2021-08-07
-
-[变更细节](../../compare/v1.0.9...v1.1.0)
+## [1.1.0](../../compare/v1.0.9...v1.1.0) - 2021-08-07
 
 - 调整内部中间件栈顺序，并对`APIv3`的正常返回内容(`20X`)做精细判断，逻辑异常时使用`\GuzzleHttp\Exception\RequestException`抛出，应用端可捕获源返回内容;
 - 对于`30X`及`4XX`,`5XX`返回，`Guzzle`基础中间件默认已处理，具体用法及使用，可参考`\GuzzleHttp\RedirectMiddleware`及`\GuzzleHttp\Middleware::httpErrors`说明；
 - 详细变化可见[1.0至1.1升级指南](UPGRADING.md)
 
-## 1.0.9 - 2021-08-05
-
-[变更细节](../../compare/v1.0.8...v1.0.9)
+## [1.0.9](../../compare/v1.0.8...v1.0.9) - 2021-08-05
 
 - 优化平台证书下载器`CertificateDownloader`异常处理逻辑部分，详见[#22](https://github.com/wechatpay-apiv3/wechatpay-php/issues/22);
 - 优化`README`使用示例的异常处理部分；
 
-## 1.0.8 - 2021-07-26
-
-[变更细节](../../compare/v1.0.7...v1.0.8)
+## [1.0.8](../../compare/v1.0.7...v1.0.8) - 2021-07-26
 
 - 增加`WeChatPay\Crypto\Hash::equals`方法，用于比较`APIv2`哈希签名值是否相等;
 - 建议使用`APIv2`的商户，在回调通知场景中，使用此方法来验签，相关说明见PHP[hash_equals](https://www.php.net/manual/zh/function.hash-equals.php)说明；
 
-## 1.0.7 - 2021-07-22
-
-[变更细节](../../compare/v1.0.6...v1.0.7)
+## [1.0.7](../../compare/v1.0.6...v1.0.7) - 2021-07-22
 
 - 完善`APIv3`及`APIv2`工厂方法初始化说明，推荐优先使用`APIv3`;
 
-## 1.0.6 - 2021-07-21
-
-[变更细节](../../compare/v1.0.5...v1.0.6)
+## [1.0.6](../../compare/v1.0.5...v1.0.6) - 2021-07-21
 
 - 调整 `Formatter::nonce` 算法，使用密码学安全的`random_bytes`生产`BASE62`随机字符串;
 
-## 1.0.5 - 2021-07-08
-
-[变更细节](../../compare/v1.0.4...v1.0.5)
+## [1.0.5](../../compare/v1.0.4...v1.0.5) - 2021-07-08
 
 - 核心代码全部转入严格类型`declare(strict_types=1)`校验模式;
 - 调整 `Authorization` 头格式顺序，debug时优先展示关键信息;
 - 调整 媒体文件`MediaUtil`类读取文件时，严格二进制读，避免跨平台干扰问题;
 - 增加 测试用例覆盖`APIv2`版用法；
 
-## 1.0.4 - 2021-07-05
-
-[变更细节](../../compare/v1.0.3...v1.0.4)
+## [1.0.4](../../compare/v1.0.3...v1.0.4) - 2021-07-05
 
 - 修正 `segments` 首字符大写时异常问题;
 - 调整 初始入参如果有提供`handler`，透传给了下游客户端问题;
 - 增加 `PHP`最低版本说明，相关问题 [#10](https://github.com/wechatpay-apiv3/wechatpay-php/issues/10);
 - 增加 测试用例已基本全覆盖`APIv3`版用法；
 
-## 1.0.3 - 2021-06-28
-
-[变更细节](../../compare/v1.0.2...v1.0.3)
+## [1.0.3](../../compare/v1.0.2...v1.0.3) - 2021-06-28
 
 - 初始化`jsonBased`入参判断，`平台证书及序列号`结构体内不能含`商户序列号`，相关问题 [#8](https://github.com/wechatpay-apiv3/wechatpay-php/issues/8);
 - 修复文档错误，相关 [#7](https://github.com/wechatpay-apiv3/wechatpay-php/issues/7);
@@ -156,9 +125,7 @@
 - 增加 `composer test` 命令并集成进 `CI` 内（测试用例持续增加中）；
 - 修复 `PHPStan` 所有遗留问题；
 
-## 1.0.2 - 2021-06-24
-
-[变更细节](../../compare/v1.0.1...v1.0.2)
+## [1.0.2](../../compare/v1.0.1...v1.0.2) - 2021-06-24
 
 - 优化了一些性能；
 - 增加 `github actions` 覆盖 PHP7.2/7.3/7.4/8.0 + Linux/macOS/Windows环境；
@@ -166,16 +133,14 @@
 - 优化 `\WeChatPay\Exception\WeChatPayException` 异常类接口；
 - 完善文档及平台证书下载器用法说明；
 
-## 1.0.1 - 2021-06-21
-
-[变更细节](../../compare/v1.0.0...v1.0.1)
+## [1.0.1](../../compare/v1.0.0...v1.0.1) - 2021-06-21
 
 - 优化了一些性能；
 - 修复了大量 `phpstan level6` 静态分析遗留问题；
 - 新增`\WeChatPay\Exception\WeChatPayException`异常类接口；
 - 完善文档及方法类型签名；
 
-## 1.0.0 - 2021-06-18
+## [1.0.0](../../compare/6782ac3..v1.0.0) - 2021-06-18
 
 源自 `wechatpay-guzzle-middleware`，不兼容源版，顾自 `v1.0.0` 开始。
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ composer install
 5. 每个 `segment` 中，若有`uri_template`动态参数<sup>[RFC6570](#note-rfc6570)</sup>，例如 `business_code/{business_code}` 推荐以`business_code->{'{business_code}'}`形式书写，其格式语义与`pathname`基本一致，阅读起来比较自然;
 6. SDK内置以 `v2` 特殊标识为 `APIv2` 的起始 `segment`，之后串接切分后的 `segments`，如源 `pay/micropay` 即串成 `v2->pay->micropay->post(['xml' => []])` 即以XML形式请求远端接口；
 7. 在IDE集成环境下，也可以按照内置的`chain($segment)`接口规范，直接以`pathname`作为变量`$segment`，来获取`OpenAPI`接入点的`endpoints`串接对象，驱动末尾执行方法(填入对应参数)，发起请求，例如 `chain('v3/pay/transactions/jsapi')->post(['json' => []])`；
+8. 在IDE环境下，可以选装 `iwechatpay/openapi` [开发辅助包](https://packagist.org/packages/iwechatpay/openapi)，源码见这里 [wechatpay-openapi](https://github.com/TheNorthMemory/wechatpay-openapi)；
 
 以下示例用法，以`异步(Async/PromiseA+)`或`同步(Sync)`结合此种编码模式展开。
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ APIv3已内置 `请求签名` 和 `应答验签` 两个middleware中间件，创
 
 ## 项目状态
 
-当前版本为`1.4.1`测试版本。
+当前版本为`1.4.2`测试版本。
 请商户的专业技术人员在使用时注意系统和软件的正确性和兼容性，以及带来的风险。
 
 **版本说明:** `开发版`指: `类库API`随时会变；`测试版`指: 少量`类库API`可能会变；`稳定版`指: `类库API`稳定持续；版本遵循[语义化版本号](https://semver.org/lang/zh-CN/)规则。
@@ -63,7 +63,7 @@ composer require wechatpay/wechatpay
 
 ```json
 "require": {
-    "wechatpay/wechatpay": "^1.4.1"
+    "wechatpay/wechatpay": "^1.4.2"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ composer install
 3. 每个 `pathname` 所支持的 `HTTP METHOD`，同时支持`Async`语法糖，例如: `v3->pay->transactions->native->postAsync(['json' => []])`;
 4. 每个 `segment` 有中线(dash)分隔符的，可以使用驼峰`camelCase`风格书写，例如: `merchant-service`可写成 `merchantService`，或如 `{'merchant-service'}`;
 5. 每个 `segment` 中，若有`uri_template`动态参数<sup>[RFC6570](#note-rfc6570)</sup>，例如 `business_code/{business_code}` 推荐以`business_code->{'{business_code}'}`形式书写，其格式语义与`pathname`基本一致，阅读起来比较自然;
-6. SDK内置以 `v2` 特殊标识为 `APIv2` 的起始 `segmemt`，之后串接切分后的 `segments`，如源 `pay/micropay` 即串成 `v2->pay->micropay->post(['xml' => []])` 即以XML形式请求远端接口；
+6. SDK内置以 `v2` 特殊标识为 `APIv2` 的起始 `segment`，之后串接切分后的 `segments`，如源 `pay/micropay` 即串成 `v2->pay->micropay->post(['xml' => []])` 即以XML形式请求远端接口；
 7. 在IDE集成环境下，也可以按照内置的`chain($segment)`接口规范，直接以`pathname`作为变量`$segment`，来获取`OpenAPI`接入点的`endpoints`串接对象，驱动末尾执行方法(填入对应参数)，发起请求，例如 `chain('v3/pay/transactions/jsapi')->post(['json' => []])`；
 
 以下示例用法，以`异步(Async/PromiseA+)`或`同步(Sync)`结合此种编码模式展开。

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "wechatpay/wechatpay",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "[A]Sync Chainable WeChatPay v2&v3's OpenAPI SDK for PHP",
     "type": "library",
     "keywords": [

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,5 @@
 parameters:
-	checkExplicitMixed: false
-	level: max
+	level: 8
 	paths:
 		- src
 		- bin

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -46,7 +46,7 @@ final class Builder
 
             /**
              * Compose the chainable `ClientDecorator` instance, most starter with the tree root point
-             * @param array<string|int> $input
+             * @param (string|int)[] $input
              * @param ?ClientDecoratorInterface $instance
              */
             public function __construct(array $input = [], ?ClientDecoratorInterface $instance = null) {

--- a/src/ClientDecoratorInterface.php
+++ b/src/ClientDecoratorInterface.php
@@ -14,7 +14,7 @@ interface ClientDecoratorInterface
     /**
      * @var string - This library version
      */
-    public const VERSION = '1.4.1';
+    public const VERSION = '1.4.2';
 
     /**
      * @var string - The HTTP transfer `xml` based protocol

--- a/src/Crypto/AesGcm.php
+++ b/src/Crypto/AesGcm.php
@@ -72,7 +72,7 @@ class AesGcm implements AesInterface
         self::preCondition();
 
         $ciphertext = base64_decode($ciphertext);
-        $authTag = substr($ciphertext, intval(-static::BLOCK_SIZE));
+        $authTag = substr($ciphertext, $tailLength = intval(-static::BLOCK_SIZE));
         $tagLength = strlen($authTag);
 
         /* Manually checking the length of the tag, because the `openssl_decrypt` was mentioned there, it's the caller's responsibility. */
@@ -80,7 +80,7 @@ class AesGcm implements AesInterface
             throw new RuntimeException('The inputs `$ciphertext` incomplete, the bytes length must be one of 16, 15, 14, 13, 12, 8 or 4.');
         }
 
-        $plaintext = openssl_decrypt(substr($ciphertext, 0, intval(-static::BLOCK_SIZE)), static::ALGO_AES_256_GCM, $key, OPENSSL_RAW_DATA, $iv, $authTag, $aad);
+        $plaintext = openssl_decrypt(substr($ciphertext, 0, $tailLength), static::ALGO_AES_256_GCM, $key, OPENSSL_RAW_DATA, $iv, $authTag, $aad);
 
         if (false === $plaintext) {
             throw new UnexpectedValueException('Decrypting the input $ciphertext failed, please checking your $key and $iv whether or nor correct.');


### PR DESCRIPTION
- 优化`Rsa::parse`代码逻辑，去除`is_resource`/`is_object`检测;
- 调整`Rsa::from[Pkcs8|Pkcs1|Spki]`加载语法糖实现，以`Rsa::from`为统一入口；
