### PR TITLE
调整`uri_template`处理顺序为先替换再选择API版本

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-php-
 
-      - run: composer config platform.php 8.0.999
-        if: matrix.php-version > 8.0
-
       - name: Install dependencies
         run: composer install --no-interaction --no-progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 # 变更历史
 
-## [1.4.2](../../compare/v1.4.1...v1.4.2) - 2021-11-08
+## [1.4.2](../../compare/v1.4.1...v1.4.2) - 2021-11-30
 
 - 优化`Rsa::parse`代码逻辑，去除`is_resource`/`is_object`检测;
 - 调整`Rsa::from[Pkcs8|Pkcs1|Spki]`加载语法糖实现，以`Rsa::from`为统一入口；
+- 优化`ClientDecorator::request[Async]`处理逻辑，优先替换`URI Template`变量，可支持短链模式调用接口；
 
 ## [1.4.1](../../compare/v1.4.0...v1.4.1) - 2021-11-03
 
 - 新增`phpstan/phpstan:^1.0`支持；
-- 优化代码，消除函数内部不安全的`Unsafe call to private|protected method|property ... through static::`调用隐患；
+- 优化代码，消除函数内部不安全的`Unsafe call to private method|property ... through static::`调用隐患；
 
 ## [1.4.0](../../compare/v1.3.2...v1.4.0) - 2021-10-24
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ GET /v3/pay/transactions/out-trade-no/{out_trade_no}
 + Path 变量的值，以同名参数传入执行方法
 + Query 参数，以名为 `query` 的参数传入执行方法
 
-以查询订单为 `GET` 例子。
+以[查询订单](https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_4_2.shtml) `GET` 方法为例：
 
 ```php
 $promise = $instance
@@ -248,7 +248,7 @@ $promise = $instance
 ]);
 ```
 
-以 [关单](https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_4_3.shtml) 为 `POST` 例子。
+以 [关单](https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_4_3.shtml) `POST` 方法为例：
 
 ```php
 $promise = $instance
@@ -530,7 +530,7 @@ AesGcm::decrypt($cert->ciphertext, $apiv3Key, $cert->nonce, $cert->associated_da
 
 v1.2 提供了统一的加载函数 `RSA::from()`。
 
-- `Rsa::from($thing, $type)` 支持从文件/字符串加载公/私钥和证书，使用方法可参考 [RsaTest.php](https://github.com/wechatpay-apiv3/wechatpay-php/blob/main/tests/Crypto/RsaTest.php)
+- `Rsa::from($thing, $type)` 支持从文件/字符串加载公/私钥和证书，使用方法可参考 [RsaTest.php](tests/Crypto/RsaTest.php)
 - `Rsa::fromPkcs1`是个语法糖，支持加载 `PKCS#1` 格式的公/私钥，入参是 `base64` 字符串
 - `Rsa::fromPkcs8`是个语法糖，支持加载 `PKCS#8` 格式的私钥，入参是 `base64` 字符串
 - `Rsa::fromSpki`是个语法糖，支持加载 `SPKI` 格式的公钥，入参是 `base64` 字符串

--- a/README_APIv2.md
+++ b/README_APIv2.md
@@ -306,3 +306,49 @@ $params += ['sign' => Hash::sign(
 
 echo json_encode($params);
 ```
+
+## v2回调通知
+
+回调通知受限于开发者/商户所使用的`WebServer`有很大差异，这里只给出开发指导步骤，供参考实现。
+
+1. 从请求头`Headers`获取`Request-ID`，商户侧`Web`解决方案可能有差异，请求头的`Request-ID`可能大小写不敏感，请根据自身应用来定；
+2. 获取请求`body`体的`XML`纯文本；
+3. 调用`SDK`内置方法，根据[签名算法](https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=4_3)做本地数据签名计算，然后与通知文本的`sign`做`Hash::equals`对比验签；
+4. 消息体需要解密的，调用`SDK`内置方法解密；
+5. 如遇到问题，请拿`Request-ID`点击[这里](https://support.pay.weixin.qq.com/online-service?utm_source=github&utm_medium=wechatpay-php&utm_content=apiv2)，联系官方在线技术支持；
+
+样例代码如下：
+
+```php
+use WeChatPay\Transformer;
+use WeChatPay\Crypto\Hash;
+use WeChatPay\Crypto\AesEcb;
+use WeChatPay\Formatter;
+
+$inBody = '';// 请根据实际情况获取，例如: file_get_contents('php://input');
+
+$apiv2Key = '';// 在商户平台上设置的APIv2密钥
+
+$inBodyArray = Transformer::toArray($inBody);
+
+// 部分通知体无`sign_type`，部分`sign_type`默认为`MD5`，部分`sign_type`默认为`HMAC-SHA256`
+// 部分通知无`sign`字典
+// 请根据官方开发文档确定
+['sign_type' => $signType, 'sign' => $sign] = $inBodyArray;
+
+$calculated = Hash::sign(
+    $signType ?? Hash::ALGO_MD5,// 如没获取到`sign_type`，假定默认为`MD5`
+    Formatter::queryStringLike(Formatter::ksort($inBodyArray)),
+    $apiv2Key
+);
+
+$signatureStatus = Hash::equals($calculated, $sign);
+
+if ($signatureStatus) {
+    // 如需要解密的
+    ['req_info' => $reqInfo] = $inBodyArray;
+    $inBodyReqInfoXml = AesEcb::decrypt($reqInfo, Hash::md5($apiv2Key));
+    $inBodyReqInfoArray = Transformer::toArray($inBodyReqInfoXml);
+    // print_r($inBodyReqInfoArray);// 打印解密后的结果
+}
+```

--- a/src/ClientDecorator.php
+++ b/src/ClientDecorator.php
@@ -133,9 +133,9 @@ final class ClientDecorator implements ClientDecoratorInterface
      */
     public function request(string $method, string $uri, array $options = []): ResponseInterface
     {
-        [$protocol, $pathname] = static::prepare($uri);
+        [$protocol, $pathname] = self::prepare(UriTemplate::expand($uri, $options));
 
-        return $this->select($protocol)->request($method, UriTemplate::expand($pathname, $options), $options);
+        return $this->select($protocol)->request($method, $pathname, $options);
     }
 
     /**
@@ -143,8 +143,8 @@ final class ClientDecorator implements ClientDecoratorInterface
      */
     public function requestAsync(string $method, string $uri, array $options = []): PromiseInterface
     {
-        [$protocol, $pathname] = static::prepare($uri);
+        [$protocol, $pathname] = self::prepare(UriTemplate::expand($uri, $options));
 
-        return $this->select($protocol)->requestAsync($method, UriTemplate::expand($pathname, $options), $options);
+        return $this->select($protocol)->requestAsync($method, $pathname, $options);
     }
 }


### PR DESCRIPTION
提供另外一种机制，以支持开发者拼接URI能力(类库大小写敏感，拼接`openid`时表现不尽人意)

例如:

```php
$instance->{'{+uri_mapping}'}->get([
    'uri_mapping' => 'v3/marketing/busifavor/users/oxTWIuGaIt6gTKsQRLau2M0yL16E/coupons/1345321/appids/wx8888888888888888'
]);
```

使用上，与 

```php
$instance->chain('{+uri_mapping}');
```
类同，只是在内部调换了一下处理`uri_template`顺序，即先替换再选择协议，应用上对于未明晰的uri形如[消费者投诉相关图片下载API](https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter10_2_18.shtml)，（`xxx` 坑位是否有大写字符完全未知)，就可以这么处理：

```php
$instance->chain('{+unclear_url_definition}')->get([
    'unclear_url_definition' => 'v3/merchant-service/images/xxxxx'
]);
```

即可避免字符被类库替换为小写问题。 spec 见 [RFC6570](https://www.rfc-editor.org/rfc/rfc6570.html#section-3.2.3) `3.2.3.  Reserved Expansion: {+var}`