### PR TITLE
optim `make stats` regarding by phpstan/phpstan:^1.8.3

### DIFF
--- a/src/Util/PemUtil.php
+++ b/src/Util/PemUtil.php
@@ -90,6 +90,6 @@ class PemUtil
             throw new UnexpectedValueException('Read the $certificate failed, please check it whether or nor correct');
         }
 
-        return strtoupper($info['serialNumberHex'] ?? '');
+        return strtoupper($info['serialNumberHex']);
     }
 }

--- a/tests/Util/MediaUtilTest.php
+++ b/tests/Util/MediaUtilTest.php
@@ -5,7 +5,7 @@ namespace WeChatPay\Tests\Util;
 use const DIRECTORY_SEPARATOR;
 
 use function dirname;
-use function hash;
+use function openssl_digest;
 use function hash_file;
 use function base64_encode;
 use function base64_decode;
@@ -47,7 +47,7 @@ class MediaUtilTest extends TestCase
                     self::FOPEN_MODE_BINARYREAD
                 ),
                 'transparent.gif',
-                hash(self::ALGO_SHA256, base64_decode($data)) ?: '', /** @phpstan-ignore-line compatible for PHP7 */
+                openssl_digest(base64_decode($data), self::ALGO_SHA256) ?: '',
             ],
             'data://text/csv;base64 string' => [//RFC2397
                 'active_user_batch_tasks_001.csv',
@@ -59,7 +59,7 @@ class MediaUtilTest extends TestCase
                     self::FOPEN_MODE_BINARYREAD
                 ),
                 'active_user_batch_tasks_001.csv',
-                hash(self::ALGO_SHA256, $data) ?: '', /** @phpstan-ignore-line compatible for PHP7 */
+                openssl_digest($data, self::ALGO_SHA256) ?: '',
             ],
         ];
     }


### PR DESCRIPTION
solved the following static checking issues:

```
 ------ -----------------------------------------------------------------------------------------
  Line   src/Util/PemUtil.php
 ------ -----------------------------------------------------------------------------------------
  93     Offset 'serialNumberHex' on array on left side of ?? always exists and is not nullable.
 ------ -----------------------------------------------------------------------------------------

 ------ --------------------------------------------
  Line   tests/Util/MediaUtilTest.php
 ------ --------------------------------------------
  50     No error to ignore is reported on line 50.
  62     No error to ignore is reported on line 62.
 ------ --------------------------------------------


 [ERROR] Found 3 errors


make: *** [stats] Error 1
```